### PR TITLE
Add iptables role

### DIFF
--- a/addons/iptables.yml
+++ b/addons/iptables.yml
@@ -1,0 +1,36 @@
+---
+# Dynamic iptables configuration. Run this playbook after running the core
+# playbook (terraform.sample.yml)
+
+# CHECK SECURITY - when customizing you should leave this in. If you take it out
+# and forget to specify security.yml, security could be turned off on components
+# in your cluster!
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: check for security
+      when: security_enabled is not defined or not security_enabled
+      fail:
+        msg: |
+          Security is not enabled. Please run `security-setup` in the root
+          directory and re-run this playbook with the `--extra-vars`/`-e` option
+          pointing to your `security.yml` (e.g., `-e @security.yml`)
+
+# CHECK CENTOS VERSION - another one you should leave in. Ensures we're using a
+# compatible and up-to-date version of Centos.
+- hosts: all
+  gather_facts: yes
+  tasks:
+    - name: check centos version
+      when: ansible_distribution_version | version_compare('7.2', '<')
+      fail:
+        msg: |
+          Your hosts don't appear to be running a compatible version of Centos.
+          Please run the playbook playbooks/upgrade-packages.yml before
+          continuing.
+
+- hosts: role=control
+  vars:
+    consul_dns_domain: consul
+  roles:
+    - iptables

--- a/roles/iptables/README.rst
+++ b/roles/iptables/README.rst
@@ -1,0 +1,17 @@
+iptables - firewall rules
+======
+
+The iptables role limits incoming IP traffic, so that only
+servers within the cluster can communicate with each other.
+The iptables rules are updated dynamically using consul-template.
+
+Some exceptions are:
+- A custom whitelist of IP addresses are allowed
+- SSH access is allowed from everywhere
+- Consul ports are open, but rate-limited (to allow new
+  members to join the cluster)
+
+All outgoing traffic from the cluster to the Internet is
+permitted. Forwarding is enabled so that docker containers
+can contact each other and its host worker nodes. Every
+server within the cluster can contact the docker containers.

--- a/roles/iptables/README.rst
+++ b/roles/iptables/README.rst
@@ -15,3 +15,6 @@ All outgoing traffic from the cluster to the Internet is
 permitted. Forwarding is enabled so that docker containers
 can contact each other and its host worker nodes. Every
 server within the cluster can contact the docker containers.
+
+This is a community supported addon, and will not be tested as frequently as
+core Mantl components.

--- a/roles/iptables/defaults/main.yml
+++ b/roles/iptables/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+iptables_allow_ips: []

--- a/roles/iptables/files/iptables-core.cfg
+++ b/roles/iptables/files/iptables-core.cfg
@@ -1,0 +1,5 @@
+template {
+	source = "/etc/consul-template/templates/iptables-core.tmpl"
+	destination = "/tmp/iptables-core.sh"
+	command = "/bin/bash /tmp/iptables-core.sh >> /tmp/consul-template-iptables-core.log"
+}

--- a/roles/iptables/tasks/main.yml
+++ b/roles/iptables/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: deploy iptables configuration
+  sudo: yes
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - src: iptables-core.cfg
+      dest: /etc/consul-template/config.d
+  notify:
+    - reload consul-template
+  tags:
+    - iptables
+
+- name: deploy iptables template
+  sudo: yes
+  template:
+    src: iptables-core.tmpl.j2
+    dest: /etc/consul-template/templates/iptables-core.tmpl
+  notify:
+    - reload consul-template
+  tags:
+    - iptables

--- a/roles/iptables/templates/iptables-core.tmpl.j2
+++ b/roles/iptables/templates/iptables-core.tmpl.j2
@@ -1,0 +1,75 @@
+#!/bin/bash
+iptables -F CLUSTER
+iptables -D INPUT -j CLUSTER
+iptables -X CLUSTER
+iptables -N CLUSTER
+
+
+{% raw %}
+# Allow all connection within the cluster
+{{range nodes}}
+iptables -A CLUSTER -s {{.Address}} -j ACCEPT{{end}}
+{% endraw %}
+iptables -A INPUT -j CLUSTER
+
+iptables -F COMMON
+iptables -D INPUT -j COMMON
+iptables -X COMMON
+iptables -N COMMON
+
+# Allow from docker0
+iptables -A COMMON -i docker0 -j ACCEPT -m comment --comment "Incoming from docker0/containers"
+
+# Allow stateful connections
+iptables -A COMMON -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+
+# Allow SSH from all IPs
+iptables -A COMMON -p tcp --dport 22 -j ACCEPT -m comment --comment "SSH access from everywhere"
+
+# Allow loopback
+iptables -I COMMON 1 -i lo -j ACCEPT -m comment --comment "Allow loopback"
+
+# IP address whitelist
+{% for allow_ip in iptables_allow_ips %}
+iptables -A COMMON -s {{ allow_ip }} -j ACCEPT -m comment --comment "Whitelisted IP"
+{% endfor %}
+
+# Allow Consul access (to let new hosts join) but rate limit the connections
+iptables -A COMMON -p tcp --dport 8300 -m limit --limit 5/s -j ACCEPT -m comment --comment "Consul (rate-limited)"
+iptables -A COMMON -p tcp --dport 8301 -m limit --limit 5/s -j ACCEPT -m comment --comment "Consul (rate-limited)"
+iptables -A COMMON -p tcp --dport 8302 -m limit --limit 5/s -j ACCEPT -m comment --comment "Consul (rate-limited)"
+iptables -A COMMON -p tcp --dport 8304 -m limit --limit 5/s -j ACCEPT -m comment --comment "Consul (rate-limited)"
+
+# Deny all other incoming packets
+iptables -A COMMON -j LOG
+iptables -A COMMON -j DROP
+
+iptables -A INPUT -j COMMON
+
+# Forwarding rules
+iptables -F CLUSTER_FORWARD
+iptables -D FORWARD -j CLUSTER_FORWARD
+iptables -X CLUSTER_FORWARD
+iptables -N CLUSTER_FORWARD
+
+# Allow traffic from docker containers
+iptables -A CLUSTER_FORWARD -i docker0 -j ACCEPT -m comment --comment "Traffic out from docker0/containers"
+
+# Allow all connection within the cluster
+{% raw %}
+{{range nodes}}
+iptables -A CLUSTER_FORWARD -s {{.Address}} -j ACCEPT{{end}}
+{% endraw %}
+
+# Allow stateful connections
+iptables -A CLUSTER_FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+
+# IP address whitelist
+{% for allow_ip in iptables_allow_ips %}
+iptables -A CLUSTER_FORWARD -s {{ allow_ip }} -j ACCEPT -m comment --comment "Whitelisted IP"
+{% endfor %}
+
+iptables -A CLUSTER_FORWARD -j LOG
+iptables -A CLUSTER_FORWARD -j DROP
+
+iptables -I FORWARD -j CLUSTER_FORWARD

--- a/terraform.sample.yml
+++ b/terraform.sample.yml
@@ -57,6 +57,7 @@
     - nginx
     - consul
     - dnsmasq
+    - iptables
 
 # ROLES - after provisioning the software that's common to all hosts, we do
 # specialized hosts. This configuration has two major groups: control nodes and

--- a/terraform.sample.yml
+++ b/terraform.sample.yml
@@ -57,7 +57,6 @@
     - nginx
     - consul
     - dnsmasq
-    - iptables
 
 # ROLES - after provisioning the software that's common to all hosts, we do
 # specialized hosts. This configuration has two major groups: control nodes and


### PR DESCRIPTION
This role lets you restrict incoming IP traffic for the
cluster to only internal cluster members. A README file
describes more in detail how it works.