### PR TITLE
Install docker-cleanup package with needed defaults

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -25,3 +25,10 @@ docker_volume_mount: /var/lib/docker
 docker_volume_device: "/dev/{{ volume_group_name }}/{{ docker_volume_name }}"
 docker_volume_fs_type: "{% if docker_storage_driver == 'btrfs' %}btrfs{% else %}xfs{% endif %}"
 docker_volume_fs_opts: "{% if docker_volume_fs_type == 'xfs' %}-i size=512{% endif %}"
+
+docker_gc:
+  exclude_containers:
+    - "# this is in an EXIT status most of the time, but is needed intact"
+    - "{{ zookeeper_data_volume }}"
+docker_cleanup_excludes: []
+docker_cleanup_container_excludes: []

--- a/roles/docker/tasks/cleanup-rpm.yml
+++ b/roles/docker/tasks/cleanup-rpm.yml
@@ -1,0 +1,25 @@
+- name: install docker-cleanup package
+  sudo: yes
+  yum:
+    name: "https://dl.bintray.com/asteris/mantl-rpm/docker-cleanup-0.0.1-1.noarch.rpm"
+    state: present
+  tags:
+    - docker
+
+- name: add default image exclusions to docker cleanup
+  sudo: yes
+  lineinfile:
+    dest: /etc/docker-cleanup/docker-gc-exclude
+    line: "{{ item }}"
+  with_items: "{{ docker_cleanup_excludes }}"
+  tags:
+    - docker
+
+- name: add default container exclusions to docker cleanup
+  sudo: yes
+  lineinfile:
+    dest: /etc/docker-cleanup/docker-gc-exclude-containers
+    line: "{{ item }}"
+  with_items: "{{ docker_cleanup_container_excludes }}"
+  tags:
+    - docker

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -183,3 +183,4 @@
     - bootstrap # needed to install Docker images during bootstrap
 
 - include: collectd.yml
+- include: cleanup-rpm.yml


### PR DESCRIPTION
In the 0.5 release, we include the docker-cleanup package as optional. We need to have this included by default, with settings that make sense for mantl. The setting that I have here was suggested by @ryane: don't cleanup the zookeeper data volume.