### PR TITLE
Calico integration with mesos 0.26.0 & marathon 0.14

### DIFF
--- a/playbooks/wait-for-hosts.yml
+++ b/playbooks/wait-for-hosts.yml
@@ -7,3 +7,8 @@
                     host="{{ ansible_ssh_host | default(inventory_hostname) }}"
                     search_regex=OpenSSH
                     delay=10
+                    
+    - name: ensure that hosts are responding
+      command: echo hello
+      register: result
+      until: result.stdout.find("hello") != -1

--- a/roles/calico/defaults/main.yml
+++ b/roles/calico/defaults/main.yml
@@ -5,8 +5,6 @@ calico_image_tag: v0.14.0
 bintray_baseurl: "https://bintray.com/artifact/download/asteris"
 calico_binary: "{{ bintray_baseurl }}/testing/calico-0.14.0-1.x86_64.rpm"
 
-calico_mesos_plugin: "https://github.com/projectcalico/calico-mesos/releases/download/v0.1.3/calico_mesos"
-
 etcd_service_name: etcd.service.{{ consul_dns_domain }}
 etcd_client_port: 2379
 

--- a/roles/calico/defaults/main.yml
+++ b/roles/calico/defaults/main.yml
@@ -1,9 +1,11 @@
 ---
 calico_image: calico/node
-calico_image_tag: v0.9.0
+calico_image_tag: v0.14.0
 
 bintray_baseurl: "https://bintray.com/artifact/download/asteris"
 calico_binary: "{{ bintray_baseurl }}/calico/calicoctl/calicoctl"
+
+calico_mesos_plugin: "https://github.com/projectcalico/calico-mesos/releases/download/v0.1.3/calico_mesos"
 
 etcd_service_name: etcd.service.{{ consul_dns_domain }}
 etcd_client_port: 2379

--- a/roles/calico/defaults/main.yml
+++ b/roles/calico/defaults/main.yml
@@ -3,7 +3,7 @@ calico_image: calico/node
 calico_image_tag: v0.14.0
 
 bintray_baseurl: "https://bintray.com/artifact/download/asteris"
-calico_binary: "{{ bintray_baseurl }}/calico/calicoctl/calicoctl"
+calico_binary: "{{ bintray_baseurl }}/testing/calico-0.14.0-1.x86_64.rpm"
 
 calico_mesos_plugin: "https://github.com/projectcalico/calico-mesos/releases/download/v0.1.3/calico_mesos"
 

--- a/roles/calico/files/modules.json
+++ b/roles/calico/files/modules.json
@@ -1,0 +1,26 @@
+{
+  "libraries": [
+    {
+      "file": "/usr/local/lib/mesos/libmesos_network_isolator.so",
+      "modules": [
+        {
+          "name": "com_mesosphere_mesos_NetworkIsolator",
+          "parameters": [
+            {
+              "key": "isolator_command",
+              "value": "/usr/local/bin/calico_mesos"
+            },
+            {
+              "key": "ipam_command",
+              "value": "/usr/local/bin/calico_mesos"
+            }
+          ]
+        },
+        {
+          "name": "com_mesosphere_mesos_NetworkHook"
+        }
+      ]
+    }
+  ]
+}
+

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -139,6 +139,8 @@
 - include: kubernetes.yml
   when: kube_build is defined
 
+- include: calico-configure.yml
+
 - name: reload calico systemd file
   sudo: yes
   command: "systemctl daemon-reload"
@@ -183,4 +185,3 @@
 
 - meta: flush_handlers
 
-- include: calico-configure.yml

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -39,6 +39,16 @@
     - calico
     - bootstrap
 
+- name: download calico-mesos plugin
+  sudo: yes
+  get_url:
+    url: "{{ calico_mesos_plugin }}"
+    dest: /usr/local/bin/calico_mesos 
+    mode: 0755
+  tags:
+    - calico
+    - bootstrap
+
 #- name: download calicoctl bash completion script
 #  sudo: yes
 #  get_url:
@@ -104,6 +114,22 @@
   when: consul_dc_group is defined
   notify:
     - reload consul
+  tags:
+    - calico
+
+- name: calico etc directory
+  sudo: yes
+  file: 
+    path: /etc/calico
+    state: directory
+  tags:
+    - calico
+
+- name: put calico-mesos integration file
+  sudo: yes
+  copy:
+    src: modules.json
+    dest: /etc/calico/modules.json
   tags:
     - calico
 

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -1,65 +1,13 @@
 ---
-# Ansible modprobe module doesn't provide such functionality
-- name: add kernel modules to load at boot time
+- name: install calico 
   sudo: yes
-  copy:
-    src: calico-modules.conf
-    dest: /etc/modules-load.d/calico-modules.conf
-    owner: root
-    group: root
-    mode: 0644
-  tags:
-    - calico
-
-- name: load kernel module xt_set
-  sudo: yes
-  modprobe:
-    name: xt_set
+  yum:
+    name: "{{ calico_binary }}"
     state: present
-  tags:
-    - calico
-
-- name: enable kernel packet forwarding
-  sudo: yes
-  sysctl:
-    name: net.ipv4.ip_forward
-    value: 1
-    state: present
-    reload: yes
-  tags:
-    - calico
-
-- name: download calicoctl binary
-  sudo: yes
-  get_url:
-    url: "{{ calico_binary }}"
-    dest: /usr/bin/calicoctl
-    mode: 0755
   tags:
     - calico
     - bootstrap
 
-- name: download calico-mesos plugin
-  sudo: yes
-  get_url:
-    url: "{{ calico_mesos_plugin }}"
-    dest: /usr/local/bin/calico_mesos 
-    mode: 0755
-  tags:
-    - calico
-    - bootstrap
-
-#- name: download calicoctl bash completion script
-#  sudo: yes
-#  get_url:
-#    url: "{{ bintray_baseurl }}/calico/calicoctl.sh"
-#    dest: /etc/bash_completion.d/calicoctl.sh
-#    mode: 0644
-#  tags:
-#    - calico
-
-# We can't use the Ansible standard docker module as it always starts
-# containers after image was pulled
 - name: ensure calico docker image is present
   sudo: yes
   command: /usr/bin/docker pull {{ calico_image }}:{{ calico_image_tag }}

--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 marathon_version: 0.13.0
-marathon_package: "https://bintray.com/artifact/download/asteris/mantl-rpm/marathon-{{ marathon_version }}-1.x86_64.rpm"
+marathon_package: "https://bintray.com/artifact/download/asteris/testing/marathon-0.14.0_RC2-1.x86_64.rpm"
 
 marathon_zk_auth: "{% if zk_marathon_user_secret is defined %}{{ zk_marathon_user }}:{{ zk_marathon_user_secret }}@{% endif %}"
 marathon_zk_dns: "zookeeper.service.{{ consul_dns_domain }}"

--- a/roles/mesos/tasks/follower.yml
+++ b/roles/mesos/tasks/follower.yml
@@ -2,7 +2,7 @@
 - name: install follower configuration
   sudo: yes
   yum:
-    name: https://bintray.com/artifact/download/asteris/mantl-rpm/mesos-agent-{{ mesos_version }}-1.noarch.rpm
+    name: https://bintray.com/artifact/download/asteris/testing/mesos-agent-0.26.0-1.noarch.rpm
     state: present
   tags:
     - mesos

--- a/roles/mesos/tasks/leader.yml
+++ b/roles/mesos/tasks/leader.yml
@@ -2,7 +2,7 @@
 - name: install leader configuration
   sudo: yes
   yum:
-    name: https://bintray.com/artifact/download/asteris/mantl-rpm/mesos-master-{{ mesos_fullversion }}.noarch.rpm
+    name: https://bintray.com/artifact/download/asteris/testing/mesos-master-0.26.0-1.noarch.rpm
     state: present
   tags:
     - mesos

--- a/roles/mesos/tasks/main.yml
+++ b/roles/mesos/tasks/main.yml
@@ -5,7 +5,8 @@
     name: "{{ item }}"
     state: present
   with_items:
-    - https://bintray.com/artifact/download/asteris/mantl-rpm/mesos-{{ mesos_version }}-2.x86_64.rpm
+    - protobuf-devel
+    - https://bintray.com/artifact/download/asteris/testing/mesos-0.26.0-2.x86_64.rpm
     - cyrus-sasl-md5
   tags:
     - mesos

--- a/roles/mesos/templates/mesos-agent.sysconfig.j2
+++ b/roles/mesos/templates/mesos-agent.sysconfig.j2
@@ -18,4 +18,9 @@ MESOS_WORK_DIR=/var/lib/mesos
 # authentication
 {% if not (do_mesos_follower_auth|bool) %}# {% endif %}MESOS_CREDENTIAL=file:///etc/sysconfig/mesos-agent-credential
 
-EXTRA_OPTS=""
+EXTRA_OPTS="{% if calico_etcdaddr is defined %}--modules=file:///etc/calico/modules.json --isolation=com_mesosphere_mesos_NetworkIsolator --hooks=com_mesosphere_mesos_NetworkHook {% endif %}"
+
+# calico integration
+{% if calico_etcdaddr is defined %}
+ETCD_AUTHORITY={{ calico_etcdaddr }}
+{% endif %}

--- a/terraform.sample.yml
+++ b/terraform.sample.yml
@@ -40,6 +40,7 @@
     - logstash
     - nginx
     - consul
+    - etcd
     - dnsmasq
 
 # ROLES - after provisioning the software that's common to all hosts, we do
@@ -61,6 +62,7 @@
     mesos_mode: follower
   roles:
     - mesos
+    - calico
 
 # the control nodes are necessarily more complex than the worker nodes, and have
 # ZooKeeper, Mesos, and Marathon leaders. In addition, they control Vault to
@@ -79,6 +81,7 @@
     - vault
     - zookeeper
     - mesos
+    - calico
     - marathon
     - chronos
     - mantlui

--- a/terraform/gce/gce.tf
+++ b/terraform/gce/gce.tf
@@ -55,6 +55,10 @@ resource "google_compute_firewall" "mi-firewall-internal" {
   source_ranges = ["${google_compute_network.mi-network.ipv4_range}"]
 
   allow {
+    protocol = "4"
+  }
+
+  allow {
     protocol = "tcp"
     ports = ["1-65535"]
   }


### PR DESCRIPTION
## DO NOT MERGE UNTIL MESOS 0.26 OR LATER IS USED IN MANTL

Before merge:
 * update bintray's repositories and mesos packaging names

Features:
* calico is packaged into rpm
* mesos is configured to use calico
* mesos 0.26 & marathon 0.14 used
