### PR TITLE
Add support for docker-network configuration

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -21,6 +21,15 @@
     - docker
     - bootstrap
 
+- name: configure docker network
+  sudo: yes
+  when: do_docker_network_config
+  template:
+    src: docker-network.sysconfig.j2
+    dest: /etc/sysconfig/docker-network
+  tags:
+    - docker
+
 - name: check if docker storage already set up with devicemapper
   sudo: yes
   shell: "test -f /etc/sysconfig/docker-storage-setup && . /etc/sysconfig/docker-storage-setup && echo ${STORAGE_DRIVER:-NOT_SET}"

--- a/roles/docker/templates/docker-network.sysconfig.j2
+++ b/roles/docker/templates/docker-network.sysconfig.j2
@@ -1,0 +1,4 @@
+# /etc/sysconfig/docker-network
+DOCKER_NETWORK_OPTIONS=
+{%- if docker_network_bridge is defined %} --bridge={{ docker_network_bridge }}{% endif -%}
+{%- if docker_network_bridge_ip is defined %} --bip={{ docker_network_bridge_ip }}{% endif -%}


### PR DESCRIPTION
This allows for docker network configuration to be specified during deployment.

Example use configuration:
```yaml
# docker networkconfiguration
do_docker_network_config: yes
docker_network_bridge: docker0
docker_network_bridge_ip: 172.16.255.1/24
```

This is useful when, for example, IP addresses conflicts with internal networks. Note both vars are optional.