### PR TITLE
Add playbook for nginx admin password update

### DIFF
--- a/playbooks/update-nginx-admin-password.yml
+++ b/playbooks/update-nginx-admin-password.yml
@@ -1,0 +1,23 @@
+---
+- hosts: role=control
+  serial: 1
+  tasks:
+    - name: encrypt admin password
+      sudo: yes
+      run_once: yes
+      shell: htpasswd -Bnb admin {{ nginx_admin_password | quote }} | cut -f 2 -d ':'
+      register: nginx_admin_password_encrypted
+      changed_when: no
+
+    - name: set admin password variable
+      run_once: yes
+      set_fact:
+        nginx_admin_password_encrypted: "{{ nginx_admin_password_encrypted.stdout }}"
+
+    - name: install nginx admin password
+      sudo: yes
+      run_once: yes
+      command: consul-cli kv-write service/nginx/auth/users/admin '{{ nginx_admin_password_encrypted }}'
+      when: nginx_admin_password_encrypted is defined
+      tags:
+        - consul


### PR DESCRIPTION
This allows for update of nginx admin password in consul k/v.
Example use:
```sh
ansible-playbook \
    -i inventory \
    -e nginx_admin_password=supers3kr37 \
    playbooks/update-nginx-admin-password.yml
```

The driver for this PR was playbook execution failures in between password generation and consul k/v persistence tasks.