### PR TITLE
Fix vault root token persistence

### DIFF
--- a/roles/vault/tasks/bootstrap.yml
+++ b/roles/vault/tasks/bootstrap.yml
@@ -45,7 +45,7 @@
   run_once: yes
   when: "'Vault is already initialized' not in vault_init_output.stdout"
   lineinfile:
-    dest: security.yml
+    dest: "{{ playbook_dir }}/security.yml"
     line: 'vault_root_token: {{ vault_token }}'
     regexp: '^vault_root_token:.*'
     insertbefore: "^zk_marathon_user:"


### PR DESCRIPTION
Attempts on persisting the token failed under Ansible 1.9.4 with the following error:
```
TASK: [vault | update security.yml with token] ******************************** 
failed: [172.17.16.66] => {"failed": true, "rc": 257}
msg: Destination security.yml does not exist !

FATAL: all hosts have already failed -- aborting
```

Using the `playbook_dir` variable fixes this issue. Additionally, errors on this task has been ignored as there is no value in failing on this one as, this is not run again unless run against new environments. The remaining steps can still continue safely with the variable in memory.