### PR TITLE
Derive defaults for consul_is_server variable

### DIFF
--- a/roles/consul/defaults/main.yml
+++ b/roles/consul/defaults/main.yml
@@ -2,10 +2,10 @@
 consul_package: https://bintray.com/artifact/download/asteris/mantl-rpm/consul-0.6.3-1.centos.x86_64.rpm
 consul_ui_package: https://bintray.com/artifact/download/asteris/mantl-rpm/consul-ui-0.6.3-1.x86_64.rpm
 consul_cli_package: https://bintray.com/artifact/download/asteris/mantl-rpm/consul-cli-0.1.0-2.x86_64.rpm
-consul_is_server: yes
 consul_dc: dc1
 consul_dc_group: dc={{ consul_dc }}
 consul_servers_group: role=control
+consul_is_server: "{{ consul_servers_group in group_names }}"
 consul_advertise: "{{ private_ipv4 }}"
 consul_retry_join: "{% for host in groups[consul_servers_group] | intersect(groups[consul_dc_group]) %}\"{{ hostvars[host].private_ipv4 }}\"{% if not loop.last %}, {% endif %}{% endfor %}"
 consul_bootstrap_expect: "{{ groups[consul_servers_group] | intersect(groups[consul_dc_group]) | length }}"


### PR DESCRIPTION
The default value for `consul_is_server` can be derived by checking if the current host is in the `consul_servers_group` group.