### PR TITLE
consul: introduce consul-docker,nginx tags

### DIFF
--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -38,6 +38,7 @@
     - reload consul
   tags:
     - consul
+    - consul-docker
 
 - name: deploy tls files
   sudo: yes
@@ -104,6 +105,8 @@
     - consul
 
 - include: nginx_proxy.yml
+  tags:
+    - consul-nginx
 
 # symlink to distributive checklist, register check with Consul
 - include: distributive.yml


### PR DESCRIPTION
- introduce the use of consul-docker and consul-nginx tags
- this allows for the consul role to be applied without dependencies on
  docker or nginx with the use of --skip-tags when executing a play

This was useful in our case where we required consul agents to be deployed on non-control/resource nodes. The specific use case was to forward consul DNS to a BIND server.

For those interested, a separate playbook was used to achieve this, with additional hosts added with `role=bind`.
```yaml
---
# To be run with --tags=bootstrap,consul --skip-tags=consul-nginx,consul-docker
- hosts: role=bind
  tasks:
    - include: roles/common/tasks/ssl.yml tags=bootstrap
  roles:
    - common
    - consul
```

BIND was preconfigured according to https://www.consul.io/docs/guides/forwarding.html