### PR TITLE
[WIP] Add ansible-lint to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
 install: "pip install -r requirements.txt"
 
 before_script:
-  - python2 testing/test-health-checks.py
   - ssh-keygen -N '' -f ~/.ssh/id_rsa && eval $(ssh-agent) && ssh-add ~/.ssh/id_rsa
   - ln -sf $ANSIBLE_PLAYBOOK terraform.yml
   - ln -sf $TERRAFORM_FILE terraform.tf
@@ -22,7 +21,10 @@ before_script:
   - curl -SL -o terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
   - unzip -d $HOME/bin terraform.zip
 
-script: python2 testing/build-cluster.py
+script:
+  - find . -name "*.yml" -exec ansible-lint {} +
+  - python2 testing/test-health-checks.py
+  - python2 testing/build-cluster.py
 
 # Just once doesn't always work
 after_script:

--- a/playbooks/upgrade-consul.yml
+++ b/playbooks/upgrade-consul.yml
@@ -18,7 +18,7 @@
       service:
         name: consul
         state: restarted
- 
+
     - name: wait for leader
       command: /usr/local/bin/consul-wait-for-leader.sh
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ ansible>=1.9.1,<2
 pytest==2.7.1
 PyYAML==3.11
 Sphinx==1.2.3
-ansible-lint>=2.2.0
+ansible-lint>=2.3.5

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -52,7 +52,7 @@
   filesystem:
     dev: "{{ docker_volume_device }}"
     fstype: "{{ docker_volume_fs_type }}"
-    opts: "{{ docker_volume_fs_opts }}" 
+    opts: "{{ docker_volume_fs_opts }}"
   when: docker_configure_lvm|bool
   tags:
     - disk

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -52,7 +52,7 @@
   filesystem:
     dev: "{{ docker_volume_device }}"
     fstype: "{{ docker_volume_fs_type }}"
-    opts: "{{ docker_volume_fs_opts }}"
+    opts: "{{ docker_volume_fs_opts }}" 
   when: docker_configure_lvm|bool
   tags:
     - disk


### PR DESCRIPTION
This PR comments out functionality in the Travis build that can't work without secrets (see #1091 for context). 

It also adds ansible-lint and syntax checking with ansible-playbook's `--syntax-check` option, so that we can use the CI build to enforce style while we wait on real testing capability. 

The changes in `docker/tasks/main.yml` and `playbooks/upgrade-consul.yml` are to bring those files into compliance with ansible-lint. 