### PR TITLE
Move logstash to HOST mode. Update collectd configuration

### DIFF
--- a/roles/collectd/templates/collectd.conf.j2
+++ b/roles/collectd/templates/collectd.conf.j2
@@ -1,7 +1,5 @@
 # collectd
 
-Hostname "{{ inventory_hostname }}"
-FQDNLookup false
 Interval 10
 Include "/etc/collectd.d/"
 TypesDB "/usr/share/collectd/types.db"
@@ -13,20 +11,17 @@ LoadPlugin "interface"
 LoadPlugin "load"
 LoadPlugin "memory"
 LoadPlugin "network"
-LoadPlugin "processes"
-LoadPlugin "swap"
 LoadPlugin "syslog"
-LoadPlugin "uptime"
-LoadPlugin "users"
 
 <Plugin "cpu">
   ReportByState true
-  ReportByCpu true
+  ReportByCpu false
   ValuesPercentage true
 </Plugin>
 
 <Plugin "memory">
   ValuesPercentage true
+  ValuesAbsolute true
 </Plugin>
 
 <Plugin "df">
@@ -68,7 +63,7 @@ LoadPlugin "users"
 </Plugin>
 
 <Plugin "syslog">
-  LogLevel "err"
+  LogLevel "info"
 </Plugin>
 
 <Plugin "network">

--- a/roles/docker/tasks/collectd.yml
+++ b/roles/docker/tasks/collectd.yml
@@ -41,12 +41,15 @@
   with_items:
     - dockerplugin.py
     - dockerplugin.db
+  tags:
+    - docker
+    - collectd
 
 - name: configure collectd docker plugin
   sudo: yes
   copy:
     src: dockerplugin.conf
-    dest: /etc/collectd.d/docker.conf
+    dest: /etc/collectd.d/dockerplugin.conf
   notify:
     - restart collectd
   tags:

--- a/roles/logstash/templates/logstash-service.j2
+++ b/roles/logstash/templates/logstash-service.j2
@@ -15,18 +15,9 @@ ExecStartPre=-/usr/bin/docker pull {{ logstash_image }}:{{ logstash_image_tag }}
 ExecStart=/usr/bin/docker run \
     --rm \
     --name=logstash \
-    --hostname={{ inventory_hostname }} \
+    --net=host \
     --log-driver=none \
     --privileged=true \
-    --publish=1514:1514 \
-    --publish=25826:25826/udp \
-    --publish=8125:8125/udp \
-{% if "'role=control' in group_names" %}
-    --publish=5678:5678/tcp \
-{% endif %}
-{% if logstash_input_log4j %}
-    --publish={{ logstash_log4j_port }}:{{ logstash_log4j_port }}/tcp \
-{% endif %}
     --volume=/etc/logstash.d:/config-dir \
     --volume=/var/lib/docker/containers:/logs/docker:ro \
     --volume=/var/log/mesos:/logs/mesos:ro \


### PR DESCRIPTION
Move Logstash docker container to HOST network mode to use /etc/hosts file for name resolution (kafka-output)
Update collectd configuration