### PR TITLE
ELK stack preinstalled.

### DIFF
--- a/roles/mesos-elasticsearch/README.rst
+++ b/roles/mesos-elasticsearch/README.rst
@@ -1,0 +1,15 @@
+Elasticsearch
+========
+
+Elasticsearch database using the Mesos Elasticsearch framework
+
+Variables
+---------
+
+You can use these variables to customize your Elasticsearch installations:
+
+.. data :: example_option_name
+
+   Example text
+
+   Default: false

--- a/roles/mesos-elasticsearch/defaults/main.yml
+++ b/roles/mesos-elasticsearch/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+framework_version: "0.7.1"
+
+elasticsearch_ram: 4096
+elasticsearch_disk: 20480
+elasticsearch_cpu: 2.0
+elasticsearch_port_http: 9200
+elasticsearch_port_transport: 9300
+elasticsearch_ports: "{{ elasticsearch_port_http }},{{ elasticsearch_port_transport }}"
+elasticsearch_cluster_name: "es-cluster"
+
+framework_name: "elasticsearch"
+framework_ui_port: 31100
+framework_use_docker: false
+framework_download_url: "https://github.com/mesos/elasticsearch/releases/download/{{ framework_version }}/scheduler-{{ framework_version }}.jar"
+
+elasticsearch_dns: "zookeeper.service.{{ consul_dns_domain }}"
+elasticsearch_http: "http://{{ elasticsearch_dns }}:{{ elasticsearch_port_http }}"

--- a/roles/mesos-elasticsearch/tasks/main.yml
+++ b/roles/mesos-elasticsearch/tasks/main.yml
@@ -1,0 +1,25 @@
+# Include mesos vars so that we can access the zk information in the json file
+- include_vars: roles/mesos/defaults/main.yml
+
+- name: create json files for jobs
+  sudo: yes
+  run_once: true
+  template:
+    src: '{{ item }}.json.j2'
+    dest: /etc/marathon/{{ item }}.json
+  with_items:
+    - mesos-elasticsearch
+  tags:
+    - mesos-elasticsearch
+
+- name: install mesos elasticsearch framework
+  run_once: true
+  sudo: yes
+  command: 'curl -X PUT -d@/etc/marathon/{{ item }}.json -H "Content-Type: application/json" http://localhost:18080/v2/apps/{{ item }}'
+  changed_when: false
+  failed_when: "'deploymentId' not in result.stdout"
+  register: result
+  with_items:
+    - mesos-elasticsearch
+  tags:
+    - mesos-elasticsearch

--- a/roles/mesos-elasticsearch/templates/mesos-elasticsearch.json.j2
+++ b/roles/mesos-elasticsearch/templates/mesos-elasticsearch.json.j2
@@ -1,0 +1,36 @@
+{
+  "id": "{{ framework_name }}",
+  "cpus": 1,
+  "mem": 512,
+  "instances": 1,
+  "uris": [
+    "{{ framework_download_url }}"
+  ],
+  "args": [ "java", "-jar", "scheduler-{{ framework_version }}.jar",
+    "--zookeeperMesosUrl", "{{ mesos_zk }}",
+    "--elasticsearchCpu", "{{ elasticsearch_cpu }}",
+    "--elasticsearchRam", "{{ elasticsearch_ram }}",
+    "--elasticsearchDisk", "{{ elasticsearch_disk }}",
+    "--elasticsearchPorts", "{{ elasticsearch_ports }}",
+    "--frameworkUseDocker", "{{ framework_use_docker }}",
+    "--elasticsearchClusterName", "{{ elasticsearch_cluster_name }}",
+    "--frameworkName", "{{ framework_name }}",
+    "--webUiPort", "{{ framework_ui_port }}"
+  ],
+  "env": {
+    "JAVA_OPTS": "-Xms32m -Xmx256m"
+  },
+  "ports": [{{ framework_ui_port }}],
+  "requirePorts": true,
+  "healthChecks": [
+    {
+      "gracePeriodSeconds": 120,
+      "intervalSeconds": 10,
+      "maxConsecutiveFailures": 6,
+      "path": "/",
+      "portIndex": 0,
+      "protocol": "HTTP",
+      "timeoutSeconds": 5
+    }
+  ]
+}

--- a/roles/mesos-kibana/README.rst
+++ b/roles/mesos-kibana/README.rst
@@ -1,0 +1,15 @@
+Kibana
+========
+
+Kibana using the Mesos Kibana framework
+
+Variables
+---------
+
+You can use these variables to customize your Kibana installations:
+
+.. data :: example_option_name
+
+   Example text
+
+   Default: false

--- a/roles/mesos-kibana/defaults/main.yml
+++ b/roles/mesos-kibana/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+kibana_version: "4.3.1"
+
+kibana_ram: 1024
+kibana_disk: 1024
+kibana_cpu: 1.0
+
+framework_name: "kibana"
+framework_version: "0.3.0"
+framework_download_url: "https://github.com/mesos/kibana/releases/download/{{ framework_version }}/kibana-{{ framework_version }}.jar"
+
+
+mesos_zk_auth: "{% if zk_mesos_user_secret is defined %}{{ zk_mesos_user }}:{{ zk_mesos_user_secret }}@{% endif %}"
+mesos_zk_dns: "zookeeper.service.{{ consul_dns_domain }}"
+mesos_zk_port: 2181
+mesos_zk_chroot: mesos
+mesos_zk: zk://{{ mesos_zk_dns }}:{{ mesos_zk_port }}/{{ mesos_zk_chroot }}
+mesos_leaders_group: role=control

--- a/roles/mesos-kibana/tasks/main.yml
+++ b/roles/mesos-kibana/tasks/main.yml
@@ -1,0 +1,26 @@
+# Include mesos vars so that we can access the zk information in the json file
+- include_vars: roles/mesos/defaults/main.yml
+- include_vars: roles/mesos-elasticsearch/defaults/main.yml
+
+- name: create json files for jobs
+  sudo: yes
+  run_once: true
+  template:
+    src: '{{ item }}.json.j2'
+    dest: /etc/marathon/{{ item }}.json
+  with_items:
+    - mesos-kibana
+  tags:
+    - mesos-kibana
+
+- name: install mesos kibana framework
+  run_once: true
+  sudo: yes
+  command: 'curl -X PUT -d@/etc/marathon/{{ item }}.json -H "Content-Type: application/json" http://localhost:18080/v2/apps/{{ item }}'
+  changed_when: false
+  failed_when: "'deploymentId' not in result.stdout"
+  register: result
+  with_items:
+    - mesos-kibana
+  tags:
+    - mesos-kibana

--- a/roles/mesos-kibana/templates/mesos-kibana.json.j2
+++ b/roles/mesos-kibana/templates/mesos-kibana.json.j2
@@ -1,0 +1,20 @@
+{
+  "id": "{{ framework_name }}",
+  "uris": [
+    "{{ framework_download_url }}"
+  ],
+  "args": ["java", "-jar", "kibana-{{ framework_version }}.jar",
+    "-zookeeper", "{{ mesos_zk }}",
+    "-version", "{{ kibana_version }}",
+    "-elasticsearch", "http://es-proxy.service.consul:9200",
+    "-mem", "{{ kibana_ram }}",
+    "-cpu", "{{ kibana_cpu }}",
+    "-disk", "{{ kibana_disk }}"
+  ],
+  "cpus": 0.2,
+  "mem": 512.0,
+  "env": {
+    "JAVA_OPTS": "-Xms128m -Xmx256m"
+  },
+  "instances": 1
+}

--- a/roles/mesos-logstash/README.rst
+++ b/roles/mesos-logstash/README.rst
@@ -1,0 +1,15 @@
+Logstash
+========
+
+Logstash using the Mesos Logstash framework
+
+Variables
+---------
+
+You can use these variables to customize your Logstash installations:
+
+.. data :: example_option_name
+
+   Example text
+
+   Default: false

--- a/roles/mesos-logstash/defaults/main.yml
+++ b/roles/mesos-logstash/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+framework_name: "logstash"
+framework_version: "0.8.0"
+framework_enable_docker: false
+framework_enable_syslog: false
+framework_enable_file: true
+framework_enable_failover: false
+framework_executor_file_path: "/var/lib/mesos/slaves/*/frameworks/*/executors/*/runs/*/stdout, /var/lib/mesos/slaves/*/frameworks/*/executors/*/runs/*/stderr, /var/log/mesos/*.INFO, /var/log/mesos/*.WARNING"
+framework_download_url: "https://github.com/mesos/logstash/releases/download/{{ framework_version }}/logstash-mesos-scheduler.jar"
+
+mesos_role: "*"
+
+
+mesos_zk_auth: "{% if zk_mesos_user_secret is defined %}{{ zk_mesos_user }}:{{ zk_mesos_user_secret }}@{% endif %}"
+mesos_zk_dns: "zookeeper.service.{{ consul_dns_domain }}"
+mesos_zk_port: 2181
+mesos_zk_chroot: mesos
+mesos_zk: zk://{{ mesos_zk_auth }}{{ mesos_zk_dns }}:{{ mesos_zk_port }}/{{ mesos_zk_chroot }}
+mesos_leaders_group: role=control
+
+logstash_heap_size: "256"
+executor_heap_size: "512"

--- a/roles/mesos-logstash/tasks/main.yml
+++ b/roles/mesos-logstash/tasks/main.yml
@@ -1,0 +1,29 @@
+# Include mesos vars so that we can access the zk information in the json file
+- include_vars: roles/mesos/defaults/main.yml
+- include_vars: roles/mesos-elasticsearch/defaults/main.yml
+
+
+- name: create json files for jobs
+  sudo: yes
+  run_once: true
+  template:
+    src: '{{ item }}.json.j2'
+    dest: /etc/marathon/{{ item }}.json
+  with_items:
+    - mesos-logstash
+  tags:
+    - mesos-logstash
+
+    
+
+- name: install mesos logstash framework
+  run_once: true
+  sudo: yes
+  command: 'curl -X PUT -d@/etc/marathon/{{ item }}.json -H "Content-Type: application/json" http://localhost:18080/v2/apps/{{ item }}'
+  changed_when: false
+  failed_when: "'deploymentId' not in result.stdout"
+  register: result
+  with_items:
+    - mesos-logstash
+  tags:
+    - mesos-logstash

--- a/roles/mesos-logstash/templates/mesos-logstash.json.j2
+++ b/roles/mesos-logstash/templates/mesos-logstash.json.j2
@@ -1,0 +1,22 @@
+{
+  "id": "{{ framework_name }}",
+  "cpus": 1,
+  "mem": 1024.0,
+  "instances": 1,
+  "uris": [
+    "{{ framework_download_url }}"
+  ],
+  "args": [ "java", "-jar", "logstash-mesos-scheduler.jar"],
+  "env": {
+    "ENABLE_DOCKER": "{{ framework_enable_docker }}",
+    "MESOS_ROLE": "{{ mesos_role }}",
+    "ZK_URL": "{{ mesos_zk }}",
+    "LOGSTASH_ELASTICSEARCH_URL": "http://es-proxy.service.consul:9200",
+    "LOGSTASH_HEAP_SIZE": "{{ logstash_heap_size }}",
+    "EXECUTOR_HEAP_SIZE": "{{ executor_heap_size }}",
+    "ENABLE_SYSLOG": "{{ framework_enable_syslog }}",
+    "ENABLE_FILE": "{{ framework_enable_file }}",
+    "ENABLE_FAILOVER": "{{ framework_enable_failover }}",
+    "EXECUTOR_FILE_PATH": "{{ framework_executor_file_path }}"
+  }
+}

--- a/roles/nginx-es/defaults/main.yml
+++ b/roles/nginx-es/defaults/main.yml
@@ -1,0 +1,4 @@
+consul_nginx_image: ciscocloud/nginx-consul
+consul_nginx_image_tag: elk
+consul_bin: /bin/consul
+consul_dir: /etc/consul

--- a/roles/nginx-es/files/es-proxy.json
+++ b/roles/nginx-es/files/es-proxy.json
@@ -1,0 +1,11 @@
+{
+  "service": {
+    "name": "es-proxy",
+    "port": 9200,
+    "check": {
+      "script": "/usr/local/bin/check-service-active nginx-elasticsearch",
+      "interval": "15s",
+      "timeout": "2s"
+    }
+  }
+}

--- a/roles/nginx-es/handlers/main.yml
+++ b/roles/nginx-es/handlers/main.yml
@@ -1,0 +1,25 @@
+---
+- name: restart nginx-elasticsearch
+  sudo: yes
+  command: systemctl restart nginx-elasticsearch
+
+- name: reload systemd
+  sudo: yes
+  command: systemctl daemon-reload
+
+- name: reload consul-template
+  sudo: yes
+  command: systemctl reload consul-template
+
+- name: reload systemd
+  sudo: yes
+  command: systemctl daemon-reload
+
+- name: reload consul
+  sudo: yes
+  command: systemctl reload consul
+  notify:
+    - wait for consul to listen
+
+- name: wait for consul to listen
+  command: /usr/local/bin/consul-wait-for-leader.sh

--- a/roles/nginx-es/tasks/main.yml
+++ b/roles/nginx-es/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+- include_vars: /roles/consul/defaults/main.yml
+
+- name: deploy nginx template 
+  sudo: yes
+  template:
+    src: elasticsearch.nginx.j2
+    dest: /etc/elasticsearch.nginx
+  register:
+    nginx_template
+  tags:
+    - nginx-es
+
+- name: deploy nginx service
+  sudo: yes
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - src: nginx-elasticsearch.service.j2
+      dest: /usr/lib/systemd/system/nginx-elasticsearch.service
+    - src: nginx-elasticsearch.env.j2
+      dest: /etc/default/nginx-elasticsearch.env
+  notify:
+    - reload systemd
+    - restart nginx-elasticsearch
+  tags:
+    - nginx-es
+
+- name: install nginx template
+  sudo: yes
+  command: consul-cli kv-write service/nginx/templates/elasticsearch @/etc/elasticsearch.nginx
+  when: nginx_template.changed
+  tags:
+    - nginx-es
+    
+- name: install nginx admin password
+  sudo: yes
+  run_once: yes
+  command: consul-cli kv-write service/nginx/auth/users/admin '{{ nginx_admin_password_encrypted }}'
+  when: nginx_admin_password_encrypted is defined
+  tags:
+    - nginx-es
+
+- name: enable nginx-elasticsearch
+  sudo: yes
+  service:
+    name: nginx-elasticsearch
+    enabled: yes
+    state: started
+  notify:
+    - restart nginx-elasticsearch
+  tags:
+    - nginx-es
+
+- name: register es-proxy with consul
+  sudo: yes
+  copy:
+    src: es-proxy.json
+    dest: /etc/consul
+  notify:
+    - reload consul
+  tags:
+    - nginx-es

--- a/roles/nginx-es/templates/elasticsearch.nginx.j2
+++ b/roles/nginx-es/templates/elasticsearch.nginx.j2
@@ -1,0 +1,58 @@
+worker_processes	1;
+
+events {
+	worker_connections	1024;
+}
+
+http {
+    upstream elasticsearch {
+     {% raw %}{{ range service "elasticsearch-executor" }}{{ if .Tags | contains "CLIENT_PORT" }}
+    server {{.Address}}:{{.Port}};{{end}}{{end}} {% endraw %}
+    }
+
+	include		mime.types;
+	default_type	application/octet-stream;
+
+	sendfile		on;
+	keepalive_timeout	65;
+
+	server {
+		listen {% raw %}{{ env "NGINX_PUBLIC_IP" }}{% endraw %}:9200 {% if do_consul_ssl|bool %}ssl{% endif %};
+
+{% if do_consul_ssl|bool %}
+		ssl_certificate		/etc/nginx/ssl/nginx.cert;
+		ssl_certificate_key	/etc/nginx/ssl/nginx.key;
+
+		ssl on;
+		ssl_session_cache	builtin:1000 shared:SSL:10m;
+		ssl_protocols		TLSv1 TLSv1.1 TLSv1.2;
+		ssl_ciphers		HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
+		ssl_prefer_server_ciphers	on;
+
+		error_page 497 https://$host:$server_port$request_uri;
+
+{% endif %}
+		location /ui/ {
+			proxy_connect_timeout	600;
+			proxy_send_timeout	600;
+			proxy_read_timeout	600;
+			send_timeout		600;
+
+{% if do_consul_auth|bool %}
+			auth_basic on;
+			auth_basic_user_file /etc/nginx/nginx-auth.conf;
+
+{% endif %}
+			proxy_pass http://localhost:8500/ui/;
+		}
+
+		location / {
+			proxy_connect_timeout	600;
+			proxy_send_timeout	600;
+			proxy_read_timeout	600;
+			send_timeout		600;
+
+			proxy_pass http://elasticsearch/;
+		}
+	}
+}

--- a/roles/nginx-es/templates/nginx-elasticsearch.env.j2
+++ b/roles/nginx-es/templates/nginx-elasticsearch.env.j2
@@ -1,0 +1,4 @@
+NGINX_KV=service/nginx/templates/elasticsearch
+NGINX_AUTH_TYPE=basic
+NGINX_AUTH_BASIC_KV=service/nginx/auth/users
+NGINX_PUBLIC_IP={{ private_ipv4 }}

--- a/roles/nginx-es/templates/nginx-elasticsearch.service.j2
+++ b/roles/nginx-es/templates/nginx-elasticsearch.service.j2
@@ -1,0 +1,28 @@
+[Unit]
+Description=nginx-elasticsearch
+After=docker.service
+After=consul.service
+Requires=docker.service
+Wants=consul.service
+
+[Service]
+Restart=on-failure
+RestartSec=20
+TimeoutStartSec=0
+
+ExecStartPre=-/usr/bin/docker rm nginx-elasticsearch
+ExecStartPre=-/usr/bin/docker pull {{ consul_nginx_image }}:{{ consul_nginx_image_tag }} 
+
+ExecStart=/usr/bin/docker run \
+    --rm \
+    --name=nginx-elasticsearch \
+    --net=host \
+    --privileged=true \
+    -v /etc/nginx/ssl:/etc/nginx/ssl:ro \
+    --env-file=/etc/default/nginx-elasticsearch.env \
+    {{ consul_nginx_image }}:{{ consul_nginx_image_tag }}  
+
+ExecStop=/usr/bin/docker kill nginx-elasticsearch
+
+[Install]
+WantedBy=multi-user.target

--- a/terraform.sample.yml
+++ b/terraform.sample.yml
@@ -16,9 +16,6 @@
     # this variable.
     # consul_acl_datacenter: your_primary_datacenter
 
-    # consul_dns_domain is repeated across these plays so that all the
-    # components know what information to use for this values to help with
-    # service discovery.
     consul_servers_group: role=control
   roles:
     - common
@@ -47,7 +44,6 @@
   # all servers, we can skip it here to speed up the deployment.
   gather_facts: no
   vars:
-    consul_dns_domain: consul
     mesos_mode: follower
   roles:
     - mesos
@@ -60,7 +56,6 @@
 - hosts: role=control
   gather_facts: no
   vars:
-    consul_dns_domain: consul
     consul_servers_group: role=control
     mesos_leaders_group: role=control
     mesos_mode: leader
@@ -90,7 +85,6 @@
 - hosts: role=control
   gather_facts: no
   vars:
-    consul_dns_domain: consul
     consul_servers_group: role=control
     mesos_leaders_group: role=control
     mesos_mode: leader

--- a/terraform.sample.yml
+++ b/terraform.sample.yml
@@ -2,16 +2,7 @@
 # CHECK SECURITY - when customizing you should leave this in. If you take it out
 # and forget to specify security.yml, security could be turned off on components
 # in your cluster!
-- hosts: localhost
-  gather_facts: no
-  tasks:
-    - name: check for security
-      when: security_enabled is not defined or not security_enabled
-      fail:
-        msg: |
-          Security is not enabled. Please run `security-setup` in the root
-          directory and re-run this playbook with the `--extra-vars`/`-e` option
-          pointing to your `security.yml` (e.g., `-e @security.yml`)
+- include: playbooks/check-requirements.yml
 
 # BASICS - we need every node in the cluster to have common software running to
 # increase stability and enable service discovery. You can look at the
@@ -28,7 +19,6 @@
     # consul_dns_domain is repeated across these plays so that all the
     # components know what information to use for this values to help with
     # service discovery.
-    consul_dns_domain: consul
     consul_servers_group: role=control
   roles:
     - common

--- a/terraform.sample.yml
+++ b/terraform.sample.yml
@@ -1,8 +1,17 @@
 ---
-# CHECK SECURITY - when customizing you should leave this in. If you
-# take it out and forget to specify security.yml, security could be turned off
-# on components in your cluster!
-- include: playbooks/check-requirements.yml
+# CHECK SECURITY - when customizing you should leave this in. If you take it out
+# and forget to specify security.yml, security could be turned off on components
+# in your cluster!
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: check for security
+      when: security_enabled is not defined or not security_enabled
+      fail:
+        msg: |
+          Security is not enabled. Please run `security-setup` in the root
+          directory and re-run this playbook with the `--extra-vars`/`-e` option
+          pointing to your `security.yml` (e.g., `-e @security.yml`)
 
 # BASICS - we need every node in the cluster to have common software running to
 # increase stability and enable service discovery. You can look at the
@@ -16,6 +25,10 @@
     # this variable.
     # consul_acl_datacenter: your_primary_datacenter
 
+    # consul_dns_domain is repeated across these plays so that all the
+    # components know what information to use for this values to help with
+    # service discovery.
+    consul_dns_domain: consul
     consul_servers_group: role=control
   roles:
     - common
@@ -44,6 +57,7 @@
   # all servers, we can skip it here to speed up the deployment.
   gather_facts: no
   vars:
+    consul_dns_domain: consul
     mesos_mode: follower
   roles:
     - mesos
@@ -56,6 +70,7 @@
 - hosts: role=control
   gather_facts: no
   vars:
+    consul_dns_domain: consul
     consul_servers_group: role=control
     mesos_leaders_group: role=control
     mesos_mode: leader
@@ -67,6 +82,32 @@
     - marathon
     - chronos
     - mantlui
+    - mesos-elasticsearch
+  
+- hosts: role=edge
+  gather_facts: no
+  vars:
+    # this is the domain that traefik will match on to do host-based HTTP
+    # routing. Set it to a domain you control and add a star domain to route
+    # traffic. (EG *.marathon.localhost)
+    #
+    # For those migrating from haproxy, this variable serves the same purpose
+    # and format as `haproxy_domain`.
+    traefik_marathon_domain: marathon.localhost
+  roles:
+    - nginx-es
+
+- hosts: role=control
+  gather_facts: no
+  vars:
+    consul_dns_domain: consul
+    consul_servers_group: role=control
+    mesos_leaders_group: role=control
+    mesos_mode: leader
+    zookeeper_server_group: role=control
+  roles:
+    - mesos-logstash
+    - mesos-kibana
 
 # The edge role exists solely for routing traffic into the cluster. Firewall
 # settings should be such that web traffic (ports 80 and 443) is exposed to the


### PR DESCRIPTION
ELK stack preinstalled for Mantl.

Uses `nginx-consul` on edge nodes as unified endpoint for ES (by now, until frameworks learn to query ES endpoints from Consul).