### PR TITLE
mantl-api: run on security-disabled clusters

### DIFF
--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -33,4 +33,4 @@ mesos_consul_refresh: "7s"
 marathon_consul_image: ciscocloud/marathon-consul
 marathon_consul_image_tag: 0.2
 mantl_api_image: ciscocloud/mantl-api
-mantl_api_image_tag: 0.1.4
+mantl_api_image_tag: 0.1.5

--- a/roles/marathon/templates/mantl-api.json.j2
+++ b/roles/marathon/templates/mantl-api.json.j2
@@ -9,14 +9,14 @@
         { "containerPort": 4001, "hostPort": 0, "protocol": "tcp" }
       ],
       "forcePullImage": true
-    },
+    }{% if do_mesos_auth %},
     "volumes": [
       {
         "containerPath": "/etc/sysconfig/mantl-api",
         "hostPath": "/etc/sysconfig/mantl-api",
         "mode": "RO"
       }
-    ]
+    ]{% endif %}
   },
   "instances": 1,
   "cpus": 0.1,


### PR DESCRIPTION
fixes #1143 