### PR TITLE
Detailed workaround on OSX for Vagrant launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Note:
 * There is no support for Windows at this time, however support is planned.
 * Vagrant 1.7.3+ is required for best results.
 * There is no support for the VMware Fusion Vagrant provider; hence your provider is set to Virtualbox in your Vagrantfile. In order to start running just issue the `vagrant up` command.
+* On OSX, if you encounter the error `ImportError: No module named yaml` while executing (`./security-setup`) and know for certain you have installed PyYAML (`pip install pyyaml`), try using the python interpretter directly: `python security-setup`.
 
 ### Software Requirements
 


### PR DESCRIPTION
Encountered error `ImportError: No module named yaml` while executing `./security-setup`.  I have PyYAML installed via Pip (and libyaml via Brew) and know that it is working (using the interpreter).  I might have a configuration issue on my laptop, but I suspect other OSX users may encounter the same issue.  Updated the README.md to note that the `security-setup` command can be executed via `python`.