### PR TITLE
gce with terraform 0.6.11

### DIFF
--- a/plugins/inventory/terraform.py
+++ b/plugins/inventory/terraform.py
@@ -393,8 +393,8 @@ def gce_host(resource, module_name):
 
     try:
         attrs.update({
-            'ansible_ssh_host': interfaces[0]['access_config'][0]['nat_ip'],
-            'public_ipv4': interfaces[0]['access_config'][0]['nat_ip'],
+            'ansible_ssh_host': interfaces[0]['access_config'][0]['assigned_nat_ip'],
+            'public_ipv4': interfaces[0]['access_config'][0]['assigned_nat_ip'],
             'private_ipv4': interfaces[0]['address'],
             'publicly_routable': True,
         })

--- a/plugins/inventory/terraform.py
+++ b/plugins/inventory/terraform.py
@@ -393,8 +393,8 @@ def gce_host(resource, module_name):
 
     try:
         attrs.update({
-            'ansible_ssh_host': interfaces[0]['access_config'][0]['assigned_nat_ip'],
-            'public_ipv4': interfaces[0]['access_config'][0]['assigned_nat_ip'],
+            'ansible_ssh_host': interfaces[0]['access_config'][0]['nat_ip'] or interfaces[0]['access_config'][0]['assigned_nat_ip'],
+            'public_ipv4': interfaces[0]['access_config'][0]['nat_ip'] or interfaces[0]['access_config'][0]['assigned_nat_ip'],
             'private_ipv4': interfaces[0]['address'],
             'publicly_routable': True,
         })

--- a/terraform/gce.sample.tf
+++ b/terraform/gce.sample.tf
@@ -1,12 +1,12 @@
 variable "control_count" { default = 3 }
 variable "datacenter" {default = "gce"}
-variable "edge_count" { default = 3}
+variable "edge_count" { default = 1}
 variable "image" {default = "centos-7-v20160119"}
 variable "long_name" {default = "mantl"}
 variable "short_name" {default = "mi"}
 variable "ssh_key" {default = "~/.ssh/id_rsa.pub"}
 variable "ssh_user" {default = "centos"}
-variable "worker_count" {default = 1}
+variable "worker_count" {default = 3}
 variable "zones" {
   default = "us-central1-a,us-central1-b"
 }

--- a/terraform/gce.sample.tf
+++ b/terraform/gce.sample.tf
@@ -18,11 +18,13 @@ provider "google" {
 }
 
 module "gce-network" {
- source = "./terraform/gce/network"
- network_ipv4 = "10.0.0.0/16"
+  source = "./terraform/gce/network"
+  network_ipv4 = "10.0.0.0/16"
+  long_name = "${var.long_name}"
+  short_name = "${var.short_name}"
 }
 
-# retmote state example
+# remote state example
 # _local is for development only s3 or something else should be used
 # https://github.com/hashicorp/terraform/blob/master/state/remote/remote.go#L47
 # https://www.terraform.io/docs/state/remote.html

--- a/terraform/gce.sample.tf
+++ b/terraform/gce.sample.tf
@@ -6,7 +6,10 @@ variable "long_name" {default = "mantl"}
 variable "short_name" {default = "mi"}
 variable "ssh_key" {default = "~/.ssh/id_rsa.pub"}
 variable "ssh_user" {default = "centos"}
-variable "worker_count" {default = 3}
+variable "worker_count" {default = 4}
+variable "control_type" { default = "n1-standard-1" }
+variable "edge_type" { default = "n1-standard-1" }
+variable "worker_type" { default = "n1-standard-2" }
 variable "zones" {
   default = "us-central1-a,us-central1-b"
 }
@@ -41,6 +44,7 @@ module "control-nodes" {
   count = "${var.control_count}"
   datacenter = "${var.datacenter}"
   image = "${var.image}"
+  machine_type = "${var.control_type}"
   network_name = "${module.gce-network.network_name}"
   #network_name = "${terraform_remote_state.gce-network.output.network_name}"
   role = "control"
@@ -55,6 +59,7 @@ module "edge-nodes" {
   count = "${var.edge_count}"
   datacenter = "${var.datacenter}"
   image = "${var.image}"
+  machine_type = "${var.edge_type}"
   network_name = "${module.gce-network.network_name}"
   #network_name = "${terraform_remote_state.gce-network.output.network_name}"
   role = "edge"
@@ -69,7 +74,7 @@ module "worker-nodes" {
   count = "${var.worker_count}"
   datacenter = "${var.datacenter}"
   image = "${var.image}"
-  machine_type = "n1-highcpu-2"
+  machine_type = "${var.worker_type}"
   network_name = "${module.gce-network.network_name}"
   #network_name = "${terraform_remote_state.gce-network.output.network_name}"
   role = "worker"

--- a/terraform/gce/instance/main.tf
+++ b/terraform/gce/instance/main.tf
@@ -71,7 +71,7 @@ resource "google_compute_instance" "instance" {
 
 
 output "gce_ips" {
-  value = "${join(\",\", google_compute_instance.instance.*.network_interface.0.access_config.0.nat_ip)}"
+  value = "${join(\",\", google_compute_instance.instance.*.network_interface.0.access_config.0.assigned_nat_ip)}"
 }
 
 output "instances" {


### PR DESCRIPTION
fixes gce provisioning when using terraform 0.6.11+

This also fixes a couple of other minor issues when using the default gce sample file.