### PR TITLE
failed to unlock neutron ports to allow calico traffic in Openstack b…

### DIFF
--- a/roles/calico/files/neutron_port_update.py
+++ b/roles/calico/files/neutron_port_update.py
@@ -52,7 +52,7 @@ def get_catalog():
                                            }
                   }
               }
-    auth_url = creds['auth_url'] + "/tokens"
+    auth_url = creds['auth_url'].strip('/') + "/tokens"
     r = requests.post(auth_url, headers=headers, data=json.dumps(payload))
 
     parsed_json = json.loads(r.text)
@@ -80,7 +80,7 @@ def list_ports(token, public_url):
 
     headers = {'X-Auth-Token': token}
     # Add '/' before 'v2.0/ports' to avoid the failure like "requests.exceptions.InvalidURL: Failed to parse: hf1-neutron.qa.webex.com:443v2" when unlock neutron ports to allow calico traffic in Openstack.
-    auth_url = public_url + "/v2.0/ports"
+    auth_url = public_url.strip('/') + "/v2.0/ports"
     r = requests.get(auth_url, headers=headers)
 
     if r.text:
@@ -105,7 +105,7 @@ def update_port(token, public_url, port_id, mac_address, calico_network):
                         }
               }
     # Add '/' before 'v2.0/ports' to avoid the failure like "requests.exceptions.InvalidURL: Failed to parse: hf1-neutron.qa.webex.com:443v2" when unlock neutron ports to allow calico traffic in Openstack.
-    auth_url = public_url + "/v2.0/ports/" + port_id
+    auth_url = public_url.strip('/') + "/v2.0/ports/" + port_id
     r = requests.put(auth_url, headers=headers, data=json.dumps(payload))
 
     parsed_json = json.loads(r.text)

--- a/roles/calico/files/neutron_port_update.py
+++ b/roles/calico/files/neutron_port_update.py
@@ -79,7 +79,8 @@ def list_ports(token, public_url):
     """List Neutron ports"""
 
     headers = {'X-Auth-Token': token}
-    auth_url = public_url + "v2.0/ports"
+    # Add '/' before 'v2.0/ports' to avoid the failure like "requests.exceptions.InvalidURL: Failed to parse: hf1-neutron.qa.webex.com:443v2" when unlock neutron ports to allow calico traffic in Openstack.
+    auth_url = public_url + "/v2.0/ports"
     r = requests.get(auth_url, headers=headers)
 
     if r.text:
@@ -103,7 +104,8 @@ def update_port(token, public_url, port_id, mac_address, calico_network):
                           ]
                         }
               }
-    auth_url = public_url + "v2.0/ports/" + port_id
+    # Add '/' before 'v2.0/ports' to avoid the failure like "requests.exceptions.InvalidURL: Failed to parse: hf1-neutron.qa.webex.com:443v2" when unlock neutron ports to allow calico traffic in Openstack.
+    auth_url = public_url + "/v2.0/ports/" + port_id
     r = requests.put(auth_url, headers=headers, data=json.dumps(payload))
 
     parsed_json = json.loads(r.text)


### PR DESCRIPTION
when deploy calico component of Mantl in Openstack, task **unlock neutron ports to allow calico traffic** failed to run because neutron_port_update.py can't parse auth url like **OS_AUTH_URL=https://hf1-keystone-srv.qa.webex.com:443/v2.0**, error log as:

```
*TASK: [calico | unlock neutron ports to allow calico traffic] *****************
failed: [mi-worker-001] => (item=mi-edge-01) => {"changed": false, "cmd": "/usr/local/bin/neutron_port_update.py \"192.168.0.0/16\" \"fa:16:3e:ac:60:18\"", "delta": "0:00:00.514603", "end": "2016-02-25 01:48:08.055803", "failed": true, "failed_when_result": true, "item": "mi-edge-01", "rc": 1, "start": "2016-02-25 01:48:07.541200", "stdout_lines": [], "warnings": []}
stderr: Traceback (most recent call last):
  File "/usr/local/bin/neutron_port_update.py", line 128, in <module>
    ports = list_ports(token, public_url)
  File "/usr/local/bin/neutron_port_update.py", line 83, in list_ports
    r = requests.get(auth_url, headers=headers)
  File "/usr/lib/python2.7/site-packages/requests/api.py", line 68, in get
    return request('get', url, **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/api.py", line 50, in request
    response = session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 450, in request
    prep = self.prepare_request(req)
  File "/usr/lib/python2.7/site-packages/requests/sessions.py", line 381, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/usr/lib/python2.7/site-packages/requests/models.py", line 304, in prepare
    self.prepare_url(url, params)
  File "/usr/lib/python2.7/site-packages/requests/models.py", line 357, in prepare_url
    raise InvalidURL(*e.args)
requests.exceptions.InvalidURL: Failed to parse: hf1-neutron.qa.webex.com:443v2.0*
```

add slash '/' before 'v2.0/ports' to fix this issue.
