### PR TITLE
Move the Chronos scheduler to an addon

### DIFF
--- a/addons/chronos.yml
+++ b/addons/chronos.yml
@@ -1,0 +1,10 @@
+# Install the Chronos job scheduler
+
+# CHECK SECURITY - when customizing you should leave this in. If you take it out
+# and forget to specify security.yml, security could be turned off on components
+# in your cluster!
+- include: "{{ playbook_dir }}/../playbooks/check-requirements.yml"
+
+- hosts: role=control
+  roles:
+    - chronos

--- a/roles/chronos/README.rst
+++ b/roles/chronos/README.rst
@@ -3,11 +3,11 @@ Chronos
 
 .. versionadded:: 0.1
 
-`Chronos <http://http://mesos.github.io/chronos/>`_ It is a distributed 
-and fault-tolerant scheduler that runs on top of Apache Mesos that can 
-be used for job orchestration. It supports custom Mesos executors as well 
-as the default command executor. 
-Thus by default, Chronos executes sh (on most systems bash) scripts.
+`Chronos <http://http://mesos.github.io/chronos/>`_ is a distributed
+and fault-tolerant scheduler that runs on top of Apache Mesos that can
+be used for job orchestration. It supports custom Mesos executors as well
+as the default command executor. By default, Chronos executes sh (on most
+systems bash) scripts.
 
 Chronos listens on port 4400.
 

--- a/sample.yml
+++ b/sample.yml
@@ -65,7 +65,6 @@
     - zookeeper
     - mesos
     - marathon
-    - chronos
     - mantlui
 
 # The edge role exists solely for routing traffic into the cluster. Firewall


### PR DESCRIPTION
Fixes #1155

When Chronos hasn't been run, the link in MantlUI acts like the Traefik link on the default Vagrant installation and returns a 404. See https://github.com/CiscoCloud/nginx-mantlui/issues/16