### PR TITLE
Add travis_wait to main testing script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - curl -SL -o terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
   - unzip -d $HOME/bin terraform.zip
 
-script: python2 testing/build-cluster.py
+script: travis_wait python2 testing/build-cluster.py
 
 # Just once doesn't always work
 after_script:


### PR DESCRIPTION
Sometimes, docker pulls hang, or there are other network issues.
Adding `travis_wait` allows the build to continue. We want this mainly
to decrease orphaned builds.