### PR TITLE
Update AMIs, remove references to old ones

### DIFF
--- a/docs/getting_started/aws.rst
+++ b/docs/getting_started/aws.rst
@@ -14,22 +14,9 @@ Before we can build any servers using Terraform and Ansible, we need to
 configure authentication. We'll be filling in the authentication variables for
 the template located at ``terraform/aws.sample.tf``. The beginning of it looks like this:
 
-.. code-block:: json
-
-  variable "control_count" { default = 3 }
-  variable "worker_count" { default = 2 }
-  variable "edge_count" { default = 2 }
-  variable "datacenter" {default = "aws-us-west-2"}
-  variable "region" {default = "us-west-2"}
-  variable "short_name" {default = "mantl"}
-  variable "source_ami" {default ="ami-d440a6e7"}
-  variable "ssh_username" {default = "centos"}
-
-  provider "aws" {
-    access_key = ""
-    secret_key = ""
-    region = "${var.region}"
-  }
+.. include:: ../../terraform/aws.sample.tf
+   :end-before: # _local is for development only
+   :code:
 
 Copy that *file* in it's entirety to the root of the project as ``aws.tf`` to start
 customization. In the next sections, we'll describe the settings that you need
@@ -178,6 +165,8 @@ This value will be dependent on the ``source_ami`` that you use. Common values
 are ``centos`` or ``ec2-user``.
 
 ``datacenter`` is a name to identify your datacenter, this is important if you have more than one datacenter.
+
+``short_name`` is appended to the name tag and dns (if used) of each of the nodes to help better identify them.
 
 ``control_count``, ``edge_count`` and ``worker_count`` are the number of EC2 instances that will get deployed for each node type.
 

--- a/docs/getting_started/aws.rst
+++ b/docs/getting_started/aws.rst
@@ -166,8 +166,6 @@ are ``centos`` or ``ec2-user``.
 
 ``datacenter`` is a name to identify your datacenter, this is important if you have more than one datacenter.
 
-``short_name`` is appended to the name tag and dns (if used) of each of the nodes to help better identify them.
-
 ``control_count``, ``edge_count`` and ``worker_count`` are the number of EC2 instances that will get deployed for each node type.
 
 ``control_type``, ``edge_type`` and ``worker_type`` are used to specify the `EC2 instance type <https://aws.amazon.com/ec2/instance-types/>`_

--- a/terraform/aws.sample.tf
+++ b/terraform/aws.sample.tf
@@ -1,14 +1,14 @@
 variable "amis" {
   default = {
-    us-east-1      = "ami-61bbf104"
-    us-west-2      = "ami-d440a6e7"
-    us-west-1      = "ami-f77fbeb3"
-    eu-central-1   = "ami-e68f82fb"
-    eu-west-1      = "ami-33734044"
-    ap-southeast-1 = "ami-2a7b6b78"
-    ap-southeast-2 = "ami-d38dc6e9"
-    ap-northeast-1 = "ami-b80b6db8"
-    sa-east-1      = "ami-fd0197e0"
+    us-east-1      = "ami-6d1c2007"
+    us-west-2      = "ami-d2c924b2"
+    us-west-1      = "ami-af4333cf"
+    eu-central-1   = "ami-9bf712f4"
+    eu-west-1      = "ami-7abd0209"
+    ap-southeast-1 = "ami-f068a193"
+    ap-southeast-2 = "ami-fedafc9d"
+    ap-northeast-1 = "ami-eec1c380"
+    sa-east-1      = "ami-26b93b4a"
   }
 }
 variable "availability_zones"  {

--- a/testing/aws.tf
+++ b/testing/aws.tf
@@ -8,7 +8,7 @@ module "aws-mantl-testing" {
   source = "./terraform/aws"
   availability_zone = "us-west-1b"
   ssh_username = "centos"
-  source_ami = "ami-f77fbeb3"
+  source_ami = "ami-af4333cf"
   short_name = "mantl-ci-${var.build_number}"
   long_name = "ciscocloud-mantl-ci-${var.build_number}"
 


### PR DESCRIPTION
Docs update removes literal inclusion of text from `aws.sample.tf`, replaces it with dynamic include.

Fixes #1178 