### PR TITLE
Gluster: change ownership of /mnt/container-volumes

### DIFF
--- a/examples/jupyter/README.md
+++ b/examples/jupyter/README.md
@@ -1,17 +1,20 @@
-# Jupyter 
-It is rather simple to deploy Jupyter on MANTL. There are some official Docker images that you can use for this purpose (https://github.com/jupyter/docker-stacks). For this example we use the jupyter/minimal-notebook.
+# Jupyter
+It is rather simple to deploy Jupyter on Mantl. There are [some official Docker
+images](https://github.com/jupyter/docker-stacks) that you can use for this
+purpose . For this example we use the jupyter/minimal-notebook.
 
+This example depends on the GlusterFS addon, please install that before trying
+this out.
 
-We wrapped the Marathon submit REST call in a small script: `deploy.sh`. You can use it to deploy Jupyter on your MANTL cluster.
+We wrapped the Marathon submit REST call in a small script: `deploy.sh`. You
+can use it to deploy Jupyter on your Mantl cluster.
 
 ```bash
 ./deploy.sh
 ```
 
-It takes a while to download the Jupyter image from DockerHub (up to 15 minutes), so please be patient the first time you deploy it. If everything went fine, you should be able to figure out the front end URL of your Jupyter deployment from the Traefik UI. Alternatively, if you deployed MANTL locally, you can even access Jupyter using the back end URL available in the Marathon UI.
-
-**Warning** Due to an issue (https://github.com/CiscoCloud/mantl/issues/1142), the Jupyter working directory won't be writable on GlusterFS. To fix this we need to ssh into a node and change the ownership of it. 
-
-```bash
-sudo chown centos /mnt/container-volumes/jupyter/
-```
+It takes up to 15 minutes to download the Jupyter image from Docker Hub, so
+please be patient the first time you deploy it. If everything went fine, you
+should be able to figure out the front end URL of your Jupyter deployment from
+the Traefik UI. Alternatively, you can access Jupyter from inside your cluster
+with the URL in the Mararthon UI.

--- a/roles/glusterfs/tasks/client.yml
+++ b/roles/glusterfs/tasks/client.yml
@@ -30,6 +30,9 @@
     name: "{{ item.mount }}"
     recurse: yes
     mode: 0755
+    # the 'ssh' in these variables is deprecated in Ansible 2.0
+    owner: "{{ ansible_ssh_user }}"
+    group: "{{ ansible_ssh_user }}"
   with_items: glusterfs_volumes
   tags:
     - glusterfs
@@ -68,5 +71,19 @@
     dest: /etc/consul/glusterfs-mounts.json
   notify:
     - reload consul
+  tags:
+    - glusterfs
+
+- name: ensure correct owner for mount points
+  sudo: yes
+  file:
+    state: directory
+    name: "{{ item.mount }}"
+    recurse: yes
+    mode: 0755
+    # the 'ssh' in these variables is deprecated in Ansible 2.0
+    owner: "{{ ansible_ssh_user }}"
+    group: "{{ ansible_ssh_user }}"
+  with_items: glusterfs_volumes
   tags:
     - glusterfs


### PR DESCRIPTION
Fixes #1142, see #1118 for context. 
Some minor copy editing and line breaking on Jupyter example.
Removed referece to bug which this commit fixes.

Tested on Vagrant:
```
[vagrant@worker-001 ~]$ ls /mnt/container-volumes/ -al
total 1
drwxr-xr-x. 4 vagrant vagrant 39 Mar  3 01:08 .
drwxr-xr-x. 3 root    root    30 Mar  3 01:09 ..
drwxr-xr-x. 3 vagrant vagrant 24 Mar  3 01:08 .trashcan
```
I think the `mount` task must change the ownership of that directory to the user that mounts it, namely `root`. 

Pinging @mcapuccini for review/testing