### PR TITLE
common: add chrony

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -46,8 +46,16 @@
     - unzip
     - jq
     - java-1.8.0-openjdk
+    - chrony
   tags:
     - bootstrap
+
+- name: enable chronyd
+  sudo: yes
+  service:
+    name: chronyd
+    enabled: yes
+    state: started
 
 - name: disable firewalld
   sudo: yes


### PR DESCRIPTION
See #811 

The default NTP client chonry isn't pre-installed on all CentOS 7 System