### PR TITLE
marathon: don't pull down docker images in advance

### DIFF
--- a/roles/marathon/tasks/jobs.yml
+++ b/roles/marathon/tasks/jobs.yml
@@ -1,15 +1,4 @@
 ---
-- name: ensure job docker images are present
-  when: provider == "vagrant"
-  sudo: yes
-  command: /usr/bin/docker pull {{ item }}
-  with_items:
-    - "{{ mesos_consul_image }}:{{ mesos_consul_image_tag }}"
-    - "{{ mantl_api_image }}:{{ mantl_api_image_tag }}"
-  tags:
-    - marathon
-    - bootstrap
-
 - name: create json files for jobs
   sudo: yes
   template:


### PR DESCRIPTION
this runs on control nodes in most environments and doesn't provide any benefit

obsoletes #1067
fixes #1062