### PR TITLE
Add OpenStack testing (via ssh) to travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install: "pip install -r requirements.txt"
 before_script:
   - python2 testing/test-health-checks.py
   - if [ "$TERRAFORM_FILE" != "OPENSTACK" ]; then ssh-keygen -N '' -f ~/.ssh/id_rsa; else echo $OS_KEY > ~/.ssh/id_rsa; chmod 400 ~/.ssh/id_rsa; fi
-  - eval $(ssh-agent) && ssh-add ~/.ssh/id_rsa
+  - eval $(ssh-agent) && ssh-add < /dev/null
   - if [ "$TERRAFORM_FILE" == "OPENSTACK" ]; then ssh-keyscan $OS_IP; fi
   - if [ "$ANSIBLE_PLAYBOOK" != "OPENSTACK" ]; then ln -sf $ANSIBLE_PLAYBOOK terraform.yml; fi
   - if [ "$TERRAFORM_FILE" != "OPENSTACK" ]; then ln -sf $TERRAFORM_FILE terraform.tf; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install: "pip install -r requirements.txt"
 
 before_script:
   - python2 testing/test-health-checks.py
-  - if [ "$TERRAFORM_FILE" != "OPENSTACK" ]; then ssh-keygen -N '' -f ~/.ssh/id_rsa; else echo $OS_KEY > ~/.ssh/id_rsa; fi
+  - if [ "$TERRAFORM_FILE" != "OPENSTACK" ]; then ssh-keygen -N '' -f ~/.ssh/id_rsa; else echo $OS_KEY > ~/.ssh/id_rsa; chmod 400 ~/.ssh/id_rsa; fi
   - eval $(ssh-agent) && ssh-add ~/.ssh/id_rsa
   - if [ "$TERRAFORM_FILE" == "OPENSTACK" ]; then ssh-keyscan $OS_IP; fi
   - if [ "$ANSIBLE_PLAYBOOK" != "OPENSTACK" ]; then ln -sf $ANSIBLE_PLAYBOOK terraform.yml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ install: "pip install -r requirements.txt"
 
 before_script:
   - python2 testing/test-health-checks.py
-  - if [ "$TERRAFORM_FILE" -ne "$OPENSTACK" ]; then ssh-keygen -N '' -f ~/.ssh/id_rsa; else echo $OS_KEY > ~/.id_rsa; fi
+  - if [ "$TERRAFORM_FILE" != "OPENSTACK" ]; then ssh-keygen -N '' -f ~/.ssh/id_rsa; else echo $OS_KEY > ~/.id_rsa; fi
   - eval $(ssh-agent) && ssh-add ~/.ssh/id_rsa
-  - if [ "$TERRAFORM_FILE" -eq "OPENSTACK" ]; then ssh-keyscan $OS_IP; fi
-  - if [ "$ANSIBLE_PLAYBOOK" -ne "OPENSTACK" ]; then ln -sf $ANSIBLE_PLAYBOOK terraform.yml; fi
-  - if [ "$TERRAFORM_FILE" -ne "OPENSTACK" ]; then ln -sf $TERRAFORM_FILE terraform.tf; fi
+  - if [ "$TERRAFORM_FILE" == "OPENSTACK" ]; then ssh-keyscan $OS_IP; fi
+  - if [ "$ANSIBLE_PLAYBOOK" != "OPENSTACK" ]; then ln -sf $ANSIBLE_PLAYBOOK terraform.yml; fi
+  - if [ "$TERRAFORM_FILE" != "OPENSTACK" ]; then ln -sf $TERRAFORM_FILE terraform.tf; fi
   - mkdir $HOME/bin && export PATH=$PATH:$HOME/bin
   - export TERRAFORM_VERSION=0.6.8
   # GCE doesn't like . in resource.name, so replace "." with "-"
@@ -26,11 +26,11 @@ before_script:
   - unzip -d $HOME/bin terraform.zip
 
 #NOTE: We will need to work all this logic into the docker container
-script: if [ "$TERRAFORM_FILE" -ne "OPENSTACK" ]; then python2 testing/build-cluster.py; else ssh travis@$OS_IP 'python2 testing/build-cluster.py'; fi
+script: if [ "$TERRAFORM_FILE" != "OPENSTACK" ]; then python2 testing/build-cluster.py; else ssh travis@$OS_IP 'python2 testing/build-cluster.py'; fi
 
 # Just once doesn't always work
 after_script:
-  - if [ "$TERRAFORM" -ne "OPENSTACK" ]; then travis_retry terraform destroy --force; else ssh travis@OS_IP 'terraform destroy --force'; fi
+  - if [ "$TERRAFORM" != "OPENSTACK" ]; then travis_retry terraform destroy --force; else ssh travis@OS_IP 'terraform destroy --force'; fi
 
 after_success: echo "slack notification here"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install: "pip install -r requirements.txt"
 
 before_script:
   - python2 testing/test-health-checks.py
-  - if [ "$TERRAFORM_FILE" != "OPENSTACK" ]; then ssh-keygen -N '' -f ~/.ssh/id_rsa; else echo $OS_KEY > ~/.id_rsa; fi
+  - if [ "$TERRAFORM_FILE" != "OPENSTACK" ]; then ssh-keygen -N '' -f ~/.ssh/id_rsa; else echo $OS_KEY > ~/.ssh/id_rsa; fi
   - eval $(ssh-agent) && ssh-add ~/.ssh/id_rsa
   - if [ "$TERRAFORM_FILE" == "OPENSTACK" ]; then ssh-keyscan $OS_IP; fi
   - if [ "$ANSIBLE_PLAYBOOK" != "OPENSTACK" ]; then ln -sf $ANSIBLE_PLAYBOOK terraform.yml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
      - TERRAFORM_FILE=testing/aws.tf ANSIBLE_PLAYBOOK=sample.yml
      - TERRAFORM_FILE=testing/do.tf  ANSIBLE_PLAYBOOK=sample.yml
      - TERRAFORM_FILE=testing/gce.tf ANSIBLE_PLAYBOOK=sample.yml
+     - TERRAFORM_FILE=OPENSTACK ANSIBLE_PLAYBOOK=OPENSTACK
     # - TERRAFORM_FILE=testing/aws.tf ANSIBLE_PLAYBOOK=kubernetes.yml
     # - TERRAFORM_FILE=testing/do.tf  ANSIBLE_PLAYBOOK=kubernetes.yml
     # - TERRAFORM_FILE=testing/gce.tf ANSIBLE_PLAYBOOK=kubernetes.yml
@@ -12,9 +13,11 @@ install: "pip install -r requirements.txt"
 
 before_script:
   - python2 testing/test-health-checks.py
-  - ssh-keygen -N '' -f ~/.ssh/id_rsa && eval $(ssh-agent) && ssh-add ~/.ssh/id_rsa
-  - ln -sf $ANSIBLE_PLAYBOOK terraform.yml
-  - ln -sf $TERRAFORM_FILE terraform.tf
+  - if [ "$TERRAFORM_FILE" -ne "$OPENSTACK" ]; then ssh-keygen -N '' -f ~/.ssh/id_rsa; else echo $OS_KEY > ~/.id_rsa; fi
+  - eval $(ssh-agent) && ssh-add ~/.ssh/id_rsa
+  - if [ "$TERRAFORM_FILE" -eq "OPENSTACK" ]; then ssh-keyscan $OS_IP; fi
+  - if [ "$ANSIBLE_PLAYBOOK" -ne "OPENSTACK" ]; then ln -sf $ANSIBLE_PLAYBOOK terraform.yml; fi
+  - if [ "$TERRAFORM_FILE" -ne "OPENSTACK" ]; then ln -sf $TERRAFORM_FILE terraform.tf; fi
   - mkdir $HOME/bin && export PATH=$PATH:$HOME/bin
   - export TERRAFORM_VERSION=0.6.8
   # GCE doesn't like . in resource.name, so replace "." with "-"
@@ -22,12 +25,11 @@ before_script:
   - curl -SL -o terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
   - unzip -d $HOME/bin terraform.zip
 
-script: python2 testing/build-cluster.py
+script: if [ "$TERRAFORM_FILE" -ne "OPENSTACK" ]; then python2 testing/build-cluster.py; else ssh travis@$OS_IP 'python2 testing/build-cluster.py'; fi
 
 # Just once doesn't always work
 after_script:
-  - terraform destroy --force || true
-  - terraform destroy --force
+  - if [ "$TERRAFORM" -ne "OPENSTACK" ]; then travis_retry terraform destroy --force; else ssh travis@OS_IP 'terraform destroy --force'; fi
 
 after_success: echo "slack notification here"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_script:
   - curl -SL -o terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
   - unzip -d $HOME/bin terraform.zip
 
+#NOTE: We will need to work all this logic into the docker container
 script: if [ "$TERRAFORM_FILE" -ne "OPENSTACK" ]; then python2 testing/build-cluster.py; else ssh travis@$OS_IP 'python2 testing/build-cluster.py'; fi
 
 # Just once doesn't always work


### PR DESCRIPTION
We need to be able to run CI against OpenStack. This approach uses ssh
to run the testing commands from a jump host maintained by Cisco Cloud.
It requires the secret env vars OS_IP and OS_KEY, which are the IP
address of the jump box, and an ssh private key, respectively. It also
requires the creation of a travis user on the jump host.

Most of the changes here are if/thens for whether we need to test
against OpenStack or not. My hope is that when we switch our deployments
to a container, this will simplify things in this file also. Right now,
it feels a bit hacky.

As part of these changes, I altered the semantics of the cleanup script:
instead of calling terraform in two lines, we will use the builtin
`travis_retry` command. It will attempt the destroy 3 times, which
should be more than enough retries for the terraform AWS bug.