### PR TITLE
dnsmasq: upgrade mantl-dns to 1.1.0

### DIFF
--- a/roles/dnsmasq/README.rst
+++ b/roles/dnsmasq/README.rst
@@ -4,6 +4,13 @@ dnsmasq
 The project uses `dnsmasq <http://www.thekelleys.org.uk/dnsmasq/doc.html>`_ to
 configure each host to use :doc:`consul` for DNS.
 
+This role also adds (as of Mantl 1.1) search paths for ``.consul`` and
+``.node.consul``. This means that you can address your nodes by their consul
+names directly: if you have a node named ``x``, you can address it there or at
+``x.node``, as well as the fully-qualified ``x.node.consul``. You can also
+address services using the shortened version (for example ``zookeeper.service``
+instead of the full ``zookeeper.service.consul``.)
+
 Changes
 -------
 
@@ -24,4 +31,4 @@ The dnsmasq role uses ``consul_dns_domain``, ``consul_servers_group``, and
 
    The version of ``mantl-dns`` to install.
 
-   Default: ``1.0.0``
+   Default: ``1.1.0``

--- a/roles/dnsmasq/defaults/main.yml
+++ b/roles/dnsmasq/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-mantl_dns_version: 1.0.0
+mantl_dns_version: 1.1.0


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release (note: I believe this to be true since I've tested upgrading 1.0.0 to 1.1.0 at the package level. I have not, however, done a full upgrade in a live Mantl cluster)
- [x] Updates documentation relevant to the changes
- [x] Rebases cleanly onto the latest master

This version adds search paths for .consul and .node.consul. This means
that where one had to type `x.node.consul` before, `x.node` and `x` will
be resolved just the same.

This also means that services can be addressed using the shorter names:
`zookeeper.service.consul` becomes `zookeeper.service`, for instance.