### PR TITLE
Add explicit dependency on libselinux-python

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -43,6 +43,7 @@
     - nc
     - openssh
     - policycoreutils-python
+    - libselinux-python
     - unzip
     - jq
     - java-1.8.0-openjdk


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [ ] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes
- [x] Rebases cleanly onto the latest master

For minimal Centos targets
Fixes #1247