### PR TITLE
consul: default log level of 'warn'

### DIFF
--- a/roles/consul/README.rst
+++ b/roles/consul/README.rst
@@ -41,6 +41,13 @@ commonly used to least.
    ``consul_servers``, IPs will be calculated from the hosts in that group and
    added to the list of servers to join. Defaults to ``role=control``.
 
+.. data:: consul_log_level
+
+   The level of logging for the Consul agent. The available log levels are
+   "trace", "debug", "info", "warn", and "err".
+
+   Default: warn
+
 .. data:: consul_gossip_key
 
    If set, this is used to encrypt gossip communication between nodes. This is

--- a/roles/consul/defaults/main.yml
+++ b/roles/consul/defaults/main.yml
@@ -5,6 +5,7 @@ consul_cli_package: consul-cli-0.1.1
 consul_dc: dc1
 consul_dc_group: dc={{ consul_dc }}
 consul_servers_group: role=control
+consul_log_level: "warn"
 consul_is_server: "{{ consul_servers_group in group_names }}"
 consul_advertise: "{{ private_ipv4 }}"
 consul_retry_join: "{% for host in groups[consul_servers_group] | intersect(groups[consul_dc_group]) %}\"{{ hostvars[host].private_ipv4 }}\"{% if not loop.last %}, {% endif %}{% endfor %}"

--- a/roles/consul/templates/consul.json.j2
+++ b/roles/consul/templates/consul.json.j2
@@ -4,6 +4,7 @@
   "node_name": "{{ inventory_hostname }}",
   "rejoin_after_leave": true,
   "domain": "{{ consul_dns_domain }}",
+  "log_level": "{{ consul_log_level }}",
   "retry_join": [ {{ consul_retry_join }} ],
 {% if consul_is_server|bool %}
   "server": true,


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes
- [x] Rebases cleanly onto the latest master

see #1241