### PR TITLE
pull request template: remove rebase requirement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,8 @@
 Hi, thank you for your contribution to Mantl! Before we can accept any code into
 master, we need it to meet the following criteria. If there are any you can't
-satisfy yourself, go ahead and open the issue anyway and we'll help you test.
-Feel free to delete this message once you're done. Thanks again!
+satisfy yourself, go ahead and open the pull request anyway and we'll help you
+test. Feel free to delete this message once you're done. Thanks again!
 
 - [ ] Installs cleanly on a fresh build of most recent master branch
 - [ ] Upgrades cleanly from the most recent release
 - [ ] Updates documentation relevant to the changes
-- [ ] Rebases cleanly onto the latest master


### PR DESCRIPTION
This should still be a requirement, but it's not helpful to have in the template because it can't really be evaluated until after all discussion and testing is finished. Having another box to check also means that in
Github's UI there are a lot of issues that have 3/4 requirements checked where the fourth is the rebase requirement, and which are otherwise completely ready for merge.

- [x] Installs cleanly on a fresh build of most recent master branch (n/a)
- [x] Upgrades cleanly from the most recent release (n/a)
- [x] Updates documentation relevant to the changes
- [ ] Rebases cleanly onto the latest master