### PR TITLE
dnsmasq: don't get latest version

### DIFF
--- a/roles/dnsmasq/tasks/main.yml
+++ b/roles/dnsmasq/tasks/main.yml
@@ -3,7 +3,7 @@
   sudo: yes
   yum:
     name: "mantl-dns-{{ mantl_dns_version }}"
-    state: latest
+    state: installed
   tags:
     - dnsmasq
     - bootstrap


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes (n/a)
- [x] Rebases cleanly onto the latest master

Using the `latest` behavior means that we get the latest version despite specifying a version. Using `installed` fixes this.

When testing, you should se the following output:

```
$ rpm -qi mantl-dns
Name        : mantl-dns
Version     : 1.0.0
Release     : 3.centos
Architecture: x86_64
Install Date: Thu 10 Mar 2016 11:40:42 PM UTC
Group       : default
Size        : 332
License     : ASL 2.0
Signature   : (none)
Source RPM  : mantl-dns-1.0.0-3.centos.src.rpm
Build Date  : Thu 10 Mar 2016 11:03:34 PM UTC
Build Host  : testing-worker-linux-docker-f69df972-3474-linux-3.prod.travis-ci.org
Relocations : /
Packager    : <travis@testing-worker-linux-docker-f69df972-3474-linux-3>
Vendor      : Asteris
URL         : https://github.com/asteris-llc/mantl-packaging
Summary     : DNS integration with Consul
Description :
DNS integration with Consul
```