### PR TITLE
Fix/mesos logrotate

### DIFF
--- a/roles/logrotate/files/mesos
+++ b/roles/logrotate/files/mesos
@@ -1,12 +1,11 @@
 /var/log/mesos/* {
         daily
         rotate 7
-        create
+        copytruncate
         missingok
         compress
         delaycompress
         notifempty
         minsize 1
-        olddir archive
 }
 

--- a/roles/logrotate/tasks/main.yml
+++ b/roles/logrotate/tasks/main.yml
@@ -45,10 +45,9 @@
     state: directory
   when: item.1
   with_together:
-    - [ mesos, docker, zookeeper ]
-    - [ true, true, role == 'control' ]
+    - [ docker, zookeeper ]
+    - [ true, role == 'control' ]
   tags:
     - docker
     - logrotate
-    - mesos
     - zookeeper

--- a/roles/mesos/files/mesos-log-cleanup
+++ b/roles/mesos/files/mesos-log-cleanup
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# delete 0 byte log files older than 1 hour
+find /var/log/mesos -size 0 -mmin +60 -delete

--- a/roles/mesos/tasks/main.yml
+++ b/roles/mesos/tasks/main.yml
@@ -19,6 +19,17 @@
   tags:
     - mesos
 
+- name: configure mesos-log-cleanup cron job
+  sudo: yes
+  copy:
+    src: mesos-log-cleanup
+    dest: /etc/cron.hourly/mesos-log-cleanup
+    owner: root
+    group: root
+    mode: 0755
+  tags:
+    - mesos
+
 - include: leader.yml
   when: mesos_mode == "leader" or mesos_mode == "mixed"
 


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes (n/a)

fixes #764 

* does not rotate logs into the /var/log/mesos/archive directory
* Every hour cleans up 0 byte mesos logs that are more than an hour old
