### PR TITLE
parameterize default http(s) ports mantlui-nginx listen on

### DIFF
--- a/roles/mantlui/README.rst
+++ b/roles/mantlui/README.rst
@@ -43,3 +43,15 @@ You can use these variables to customize your Mantlui installation.
    Use basic authentication to secure the mantlui.
 
    default: ``false``
+
+.. data:: mantlui_nginx_http_port
+
+   nginx-mantlui http port
+
+   default: ``80``
+
+.. data:: mantlui_nginx_https_port
+
+   nginx-mantlui https port
+
+   default: ``443``

--- a/roles/mantlui/defaults/main.yml
+++ b/roles/mantlui/defaults/main.yml
@@ -1,4 +1,6 @@
 mantlui_nginx_image: ciscocloud/nginx-mantlui
 mantlui_nginx_image_tag: 0.6.5
+mantlui_nginx_http_port: 80
+mantlui_nginx_https_port: 443
 do_mantlui_ssl: false
 do_mantlui_auth: false

--- a/roles/mantlui/templates/nginx-mantlui.service.j2
+++ b/roles/mantlui/templates/nginx-mantlui.service.j2
@@ -17,8 +17,8 @@ ExecStart=/usr/bin/docker run \
     --rm \
     --name=nginx-mantlui \
     --env-file=/etc/default/nginx-mantlui.env \
-    -p 80:80 \
-    -p 443:443 \
+    -p {{ mantlui_nginx_http_port }}:80 \
+    -p {{ mantlui_nginx_https_port }}:443 \
     -v /etc/nginx/ssl:/etc/nginx/ssl:ro \
     -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/:ro \
     {{ mantlui_nginx_image }}:{{ mantlui_nginx_image_tag }}


### PR DESCRIPTION
Reading [this article](http://bigdata-streaming.com/2016/03/07/mantl-new-step-in-microservices-orchestration-scalable-deployments-part-2-single-node-deploy-example/) i've found that mantlui-nginx listening on 80 port is the only thing that prevent's mantl from deploying&working on a single node. Traefik binds to :80 port too, and seems more suitable. With this PR default ports for mantui-nginx may be changed easily in playbook.

Can't found any suitable place in documentation for that. 
- [X] Installs cleanly on a fresh build of most recent master branch
- [ ] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

