### PR TITLE
replace public ips with elastic ips so they remain fixed on reboots

### DIFF
--- a/docs/getting_started/aws.rst
+++ b/docs/getting_started/aws.rst
@@ -193,6 +193,8 @@ Terraform to provision your cluster, ``terraform plan`` to see what will be
 created, and ``terraform apply`` to provision the cluster.
 
 After ``terraform apply`` has completed without errors, you're ready to continue.
+If you are using elastic ips on aws, you need to run ``terraform refresh`` to allow the eips to replace the public ips due to terraform issue 5407. 
+For more than 5 elastic ips, you must `submit a request <http://aws.amazon.com/contact-us/eip_limit_request/>`_ to increase your limit but they are trivially inexpensive.
 Next, follow the instructions at :doc:`getting started <index>` to install
 Mantl on your new AWS VM's
 

--- a/sample.yml
+++ b/sample.yml
@@ -4,11 +4,23 @@
 # on components in your cluster!
 - include: "{{ playbook_dir }}/playbooks/check-requirements.yml"
 
+# If using elastic ips on aws, we need to refresh terraform so that the public_ips
+# pick up the elastic ips, not the original non-elastic public ips.  This is due to
+# a bug in terraform https://github.com/hashicorp/terraform/issues/5407
+# For more than 5 elastic ips, you must submit a request to increase your limit
+# but they are trivially cheap http://aws.amazon.com/contact-us/eip_limit_request/
+- hosts: localhost
+  gather_facts: no
+  tasks:
+   - name: refresh terraform
+     shell: terraform refresh
+
 # BASICS - we need every node in the cluster to have common software running to
 # increase stability and enable service discovery. You can look at the
 # documentation for each of these components in their README file in the
 # `roles/` directory, or by checking the online documentation at
 # docs.mantl.io.
+
 - hosts: all
   vars:
     # consul_acl_datacenter should be set to the datacenter you want to control

--- a/terraform/aws/instance/main.tf
+++ b/terraform/aws/instance/main.tf
@@ -13,7 +13,9 @@ variable "source_ami" {}
 variable "security_group_ids" {}
 variable "vpc_subnet_ids" {}
 variable "ssh_username" {default = "centos"}
-
+# elastic ips are required if you wish to reboot instances without losing public ips
+variable "use_elastic_ips" {default = 0}
+variable "associate_public_ip_address" {default = "true"}
 
 resource "aws_ebs_volume" "ebs" {
   availability_zone = "${element(split(",", var.availability_zones), count.index)}"
@@ -33,7 +35,7 @@ resource "aws_instance" "instance" {
   count = "${var.count}"
   vpc_security_group_ids = [ "${split(",", var.security_group_ids)}"]
   key_name = "${var.ssh_key_pair}"
-  associate_public_ip_address = true
+  associate_public_ip_address = "${var.associate_public_ip_address}"
   subnet_id = "${element(split(",", var.vpc_subnet_ids), count.index)}" 
   iam_instance_profile = "${var.iam_profile}"
   root_block_device {
@@ -50,6 +52,11 @@ resource "aws_instance" "instance" {
   }
 }
 
+resource "aws_eip" "eip" {
+    count = "${var.count * var.use_elastic_ips}"
+    instance = "${element(aws_instance.instance.*.id, count.index)}"
+    vpc = true
+}
 
 resource "aws_volume_attachment" "instance-lvm-attachment" {
   count = "${var.count}"
@@ -58,7 +65,6 @@ resource "aws_volume_attachment" "instance-lvm-attachment" {
   volume_id = "${element(aws_ebs_volume.ebs.*.id, count.index)}"
   force_detach = true
 }
-
 
 
 output "hostname_list" {
@@ -72,3 +78,8 @@ output "ec2_ids" {
 output "ec2_ips" {
   value = "${join(\",\", aws_instance.instance.*.public_ip)}"
 }
+
+output "ec2_eips" {
+  value = "${join(\",\", aws_eip.eip.*.public_ip)}"
+}
+


### PR DESCRIPTION
When running the reboot-hosts.yml playbook on aws, the public_ips might be refreshed with new values.  Although a typical reboot from the UI will not change the public_ip, if you stop and then restart an instance you will likely get new public_ips.

They should be elastic_ips.
Adding the few lines in this patch produce eips for all instances and reboots at least have a chance.
I haven't tested fully enough to know if this solves all the reboot-hosts issues.

Not sure if these similar issues are related, as they were on CCS.
https://github.com/CiscoCloud/mantl/issues/1144
https://github.com/CiscoCloud/mantl/issues/1238

Currently there is a [bug in terraform](https://github.com/hashicorp/terraform/issues/5407) that does not swap the public_ip for the eip immediately.  It requires a refresh.  This pr will likely need to wait until that bug is resolved, but adding the PR so i can have it code reviewed.




