### PR TITLE
adding task during ansible-playbook to install yum-utils

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -18,6 +18,13 @@
   tags:
     - common
 
+- name: add yum-config-manager
+  sudo: yes
+  yum:
+    name: yum-utils
+  tags:
+    - bootstrap
+
 - name: increase timeouts in YUM
   sudo: yes
   shell: "yum-config-manager --save --setopt {{ item.option }}={{ item.value }}"


### PR DESCRIPTION
When deploying Mantl via ansible-playbook, an assumption is made that the OS already has yum-utils installed when trying to increase the yum timeout, failing the deployment if yum-config-manager is not present. 

Added a task that can install yum-utils (contains yum-config-manager) as a prerequisite.