### PR TITLE
mesos: refactor logging

### DIFF
--- a/roles/logrotate/files/mesos
+++ b/roles/logrotate/files/mesos
@@ -1,12 +1,10 @@
 /var/log/mesos/* {
         daily
         rotate 7
-        create
+        copytruncate
         missingok
         compress
         delaycompress
         notifempty
         minsize 1
-        olddir archive
 }
-

--- a/roles/logrotate/tasks/main.yml
+++ b/roles/logrotate/tasks/main.yml
@@ -45,8 +45,8 @@
     state: directory
   when: item.1
   with_together:
-    - [ mesos, docker, zookeeper ]
-    - [ true, true, role == 'control' ]
+    - [ docker, zookeeper ]
+    - [ true, role == 'control' ]
   tags:
     - docker
     - logrotate

--- a/roles/logstash/templates/logstash.conf.j2
+++ b/roles/logstash/templates/logstash.conf.j2
@@ -1,7 +1,7 @@
 input {
 {% if 'role=control' in group_names %}
   file {
-    path => [ "/logs/mesos/*.INFO", "/logs/mesos/*.WARNING", "/logs/mesos/*.ERROR", "/logs/mesos/*.FATAL" ]
+    path => "/logs/mesos/mesos-master.log"
     type => "mesos-master-logs"
   }
   http {
@@ -16,8 +16,8 @@ input {
 {% endif %}
 {% if 'role=worker' in group_names %}
   file {
-    path => [ "/logs/mesos/*.INFO", "/logs/mesos/*.WARNING", "/logs/mesos/*.ERROR", "/logs/mesos/*.FATAL" ]
-    type => "mesos-slave-logs"
+    path => "/logs/mesos/mesos-agent.log"
+    type => "mesos-agent-logs"
   }
   file {
     path => [ "/logs/slaves/*/frameworks/*/executors/*/runs/*/stdout", "/logs/slaves/*/frameworks/*/executors/*/runs/*/stderr" ]

--- a/roles/mesos/handlers/main.yml
+++ b/roles/mesos/handlers/main.yml
@@ -32,3 +32,9 @@
   service:
     name: collectd
     state: restarted
+
+- name: restart rsyslog
+  sudo: yes
+  service:
+    name: rsyslog
+    state: restarted

--- a/roles/mesos/tasks/main.yml
+++ b/roles/mesos/tasks/main.yml
@@ -19,6 +19,22 @@
   tags:
     - mesos
 
+- name: create mesos entries for syslogd
+  sudo: yes
+  copy:
+    dest: /etc/rsyslog.d/20-mesos.conf
+    content: |
+      # Mesos logging
+      :syslogtag, isequal, "mesos-slave:"  /var/log/mesos/mesos-agent.log
+      :syslogtag, isequal, "mesos-master:"  /var/log/mesos/mesos-master.log
+      & ~
+  notify:
+    - restart rsyslog
+  tags:
+    - mesos
+
+- meta: flush_handlers
+
 - include: leader.yml
   when: mesos_mode == "leader" or mesos_mode == "mixed"
 

--- a/roles/mesos/templates/mesos-agent.sysconfig.j2
+++ b/roles/mesos/templates/mesos-agent.sysconfig.j2
@@ -2,7 +2,7 @@
 MESOS_PORT={{ mesos_follower_port }}
 MESOS_ADVERTISE_IP={{ private_ipv4 }}
 MESOS_HOSTNAME={{ mesos_hostname | default(inventory_hostname + ".node." + consul_dns_domain) }}
-MESOS_LOG_DIR={{ mesos_log_dir }}
+MESOS_EXTERNAL_LOG_FILE=/var/log/mesos/mesos-agent.log
 MESOS_LOGGING_LEVEL={{ mesos_logging_level }}
 
 # agent configuration

--- a/roles/mesos/templates/mesos-master.sysconfig.j2
+++ b/roles/mesos/templates/mesos-master.sysconfig.j2
@@ -2,7 +2,7 @@
 MESOS_PORT={{ mesos_leader_port }}
 MESOS_ADVERTISE_IP={{ private_ipv4 }}
 MESOS_HOSTNAME={{ mesos_hostname | default(inventory_hostname + ".node." + consul_dns_domain) }}
-MESOS_LOG_DIR={{ mesos_log_dir }}
+MESOS_EXTERNAL_LOG_FILE=/var/log/mesos/mesos-master.log
 MESOS_LOGGING_LEVEL={{ mesos_logging_level }}
 
 # master configuration


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes (n/a)

- don't use MESOS_LOG_DIR
- stdout/stderr is logged to journal
- rsyslog sends mesos-master and mesos-agent logs to files
- updated logrotate config
- updated logstash rules

Fixes #764