### PR TITLE
patch use builtin vsphere provider

### DIFF
--- a/docs/getting_started/vsphere.rst
+++ b/docs/getting_started/vsphere.rst
@@ -1,7 +1,7 @@
 VMware vSphere
 ================
 
-You can bring up VMware vSphere environment using Terraform with third-party vSphere provider.
+You can bring up VMware vSphere environment using Terraform with builtin vSphere provider.
 
 Prerequisites
 ---------------
@@ -11,11 +11,6 @@ Terraform
 
 Install Terraform according to the `guide <https://www.terraform.io/intro/getting-started/install.html>`_. 
 
-vSphere plugin
-^^^^^^^^^^^^^^^^
-
-Download `vSphere plugin <https://github.com/mkuzmin/terraform-vsphere/releases>`_ for Terraform. `Install <https://terraform.io/docs/plugins/basics.html>`_ it, or put into a directory with Terraform binaries or configuration files.
-The detailed information about this plugin you can find `here <https://github.com/mkuzmin/terraform-vsphere>`_
 
 VMware template
 ^^^^^^^^^^^^^^^^^
@@ -30,8 +25,8 @@ Configuring vSphere for Terraform
 
 Provider settings
 ^^^^^^^^^^^^^^^^^^^
-``vcenter_server``, ``user`` and ``password`` are the required parameters needed by Terraform to interact with resources in your vSphere.
-``insecure_connection`` parameter is reponsible for checking SSL certificates of the vCenter. If you have self-signed certificates it is necessary to set this parameter to ``false``.
+``vsphere_server``, ``user`` and ``password`` are the required parameters needed by Terraform to interact with resources in your vSphere.
+``allow_unverified_ssl`` parameter is reponsible for checking SSL certificates of the vCenter. If you have self-signed certificates it is necessary to set this parameter to ``true``.
 
 .. envvar:: VSPHERE_USER
 
@@ -46,11 +41,13 @@ Basic settings
 
 ``datacenter`` is the name of datacenter in your vSphere environment. It is required if the vSphere has several datacenters.
 
-``host`` is the hostname or IP address of ESXi host in the selected datacenter.
+``cluster`` is the name of the cluster in the selected datacenter. It's an optional parameter.
 
 ``pool`` is the name of resource pool in vSphere. It's an optional parameter.
 
 ``template`` is the name of a base VM or template you will deploy you machines from. Should include a path in VM folder hierarchy: ``folder/subfolder/vm-name``
+
+``network_label`` is the label of the network assigned to the machines.
 
 ``short_name`` is the prefix that will be used for the new virtual machines.
 
@@ -81,6 +78,7 @@ Provisioning
 --------------
 
 Once you're all set up with the provider, customize your module, run ``terraform get`` to prepare Terraform to provision your cluster, ``terraform plan`` to see what will be created, and ``terraform apply`` to provision the cluster. At the end of provisioning Terraform will perform commands to change hostnames for correct service work. You can change this behavior in the ``provisioner`` section for each resource in the ``terraform/vsphere/main.tf`` file. 
+Due to a timing condition when requesting a MAC address from the vsphere server (``ethernet0.addressType = "vpx"``) you may have to apply without the provisioner for a first time and issue ``terraform apply`` (with provisioner) afterwards. This will allow the guest tools to provide the IP addresses.
 
 Afterwards, you can
 use the instructions in :doc:`getting started <index>` to install

--- a/terraform/vsphere.sample.tf
+++ b/terraform/vsphere.sample.tf
@@ -1,8 +1,8 @@
 provider "vsphere" {
-  vcenter_server = ""
+  vsphere_server = ""
   user = ""
   password = ""
-  insecure_connection = ""
+  allow_unverified_ssl = "false"
 }
 
 module "vsphere-dc" {
@@ -10,9 +10,11 @@ module "vsphere-dc" {
   long_name = ""
   short_name = ""
   datacenter = ""
-  host = ""
+  cluster = ""
   pool = ""
   template = ""
+  network_label = ""
+  datastore = ""
   control_count = 3
   worker_count = 4
   edge_count = 2

--- a/terraform/vsphere/main.tf
+++ b/terraform/vsphere/main.tf
@@ -1,10 +1,12 @@
 variable "datacenter" {}
-variable "host" {}
+variable "cluster" {}
 variable "pool" {}
 variable "template" {}
 variable "ssh_user" {}
 variable "ssh_key" {}
 variable "consul_dc" {}
+variable "datastore" {}
+variable "network_label" {}
 
 variable "short_name" {default = "mantl"}
 variable "long_name" {default = "mantl"}
@@ -24,17 +26,22 @@ variable "edge_ram" { default = 4096 }
 
 resource "vsphere_virtual_machine" "mi-control-nodes" {
   name = "${var.short_name}-control-${format("%02d", count.index+1)}"
-  image = "${var.template}"
 
   datacenter = "${var.datacenter}"
-  host = "${var.host}"
+  cluster = "${var.cluster}"
   resource_pool = "${var.pool}"
 
-  cpus = "${var.control_cpu}"
+  vcpu = "${var.control_cpu}"
   memory = "${var.control_ram}"
 
   disk {
     size = "${var.control_volume_size}"
+    template = "${var.template}"
+    datastore = "${var.datastore}"
+  }
+
+  network_interface {
+    label = "${var.network_label}"
   }
 
   custom_configuration_parameters = {
@@ -58,17 +65,22 @@ resource "vsphere_virtual_machine" "mi-control-nodes" {
 
 resource "vsphere_virtual_machine" "mi-worker-nodes" {
   name = "${var.short_name}-worker-${format("%03d", count.index+1)}"
-  image = "${var.template}"
 
   datacenter = "${var.datacenter}"
-  host = "${var.host}"
+  cluster = "${var.cluster}"
   resource_pool = "${var.pool}"
 
-  cpus = "${var.worker_cpu}"
+  vcpu = "${var.worker_cpu}"
   memory = "${var.worker_ram}"
 
   disk {
     size = "${var.worker_volume_size}"
+    template = "${var.template}"
+    datastore = "${var.datastore}"
+  }
+
+  network_interface {
+    label = "${var.network_label}"
   }
 
   custom_configuration_parameters = {
@@ -92,17 +104,22 @@ resource "vsphere_virtual_machine" "mi-worker-nodes" {
 
 resource "vsphere_virtual_machine" "mi-edge-nodes" {
   name = "${var.short_name}-edge-${format("%02d", count.index+1)}"
-  image = "${var.template}"
 
   datacenter = "${var.datacenter}"
-  host = "${var.host}"
+  cluster = "${var.cluster}"
   resource_pool = "${var.pool}"
 
-  cpus = "${var.edge_cpu}"
+  vcpu = "${var.edge_cpu}"
   memory = "${var.edge_ram}"
 
   disk {
     size = "${var.edge_volume_size}"
+    template = "${var.template}"
+    datastore = "${var.datastore}"
+  }
+
+  network_interface {
+    label = "${var.network_label}"
   }
 
   custom_configuration_parameters = {


### PR DESCRIPTION
Works against ESXi 6.0, template needs to have the latest VMware tools installed, or else the customization will not work.

- [ ] Installs cleanly on a fresh build of most recent master branch
- [ ] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes
