### PR TITLE
make dns and route53 names consistent with /etc/hosts

### DIFF
--- a/terraform/aws.sample.tf
+++ b/terraform/aws.sample.tf
@@ -112,6 +112,7 @@ module "edge-nodes" {
 module "worker-nodes" {
   source = "./terraform/aws/instance"
   count = "${var.worker_count}"
+  count_format = "%03d"
   datacenter = "${var.datacenter}"
   data_ebs_volume_size = "100"
   role = "worker"

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -1,5 +1,7 @@
 variable "availability_zone" {}
 variable "control_count" {default = "3"}
+variable "count_format" {default = "%02d"}
+variable "worker_count_format" {default = "%03d"}
 variable "control_iam_profile" {default = "" }
 variable "control_type" {default = "m3.medium"}
 variable "control_volume_size" {default = "20"} # size is in gigabytes
@@ -149,7 +151,7 @@ resource "aws_instance" "mi-worker-nodes" {
   }
 
   tags {
-    Name = "${var.short_name}-worker-${format("%03d", count.index+1)}"
+    Name = "${var.short_name}-worker-${format(var.worker_count_format, count.index+1)}"
     sshUser = "${var.ssh_username}"
     role = "worker"
     dc = "${var.datacenter}"

--- a/terraform/aws/instance/main.tf
+++ b/terraform/aws/instance/main.tf
@@ -1,4 +1,5 @@
 variable "count" {default = "4"}
+variable "count_format" {default = "%02d"}
 variable "iam_profile" {default = "" }
 variable "ec2_type" {default = "m3.medium"}
 variable "ebs_volume_size" {default = "20"} # size is in gigabytes
@@ -21,9 +22,10 @@ resource "aws_ebs_volume" "ebs" {
   type = "gp2"
 
   tags {
-    Name = "${var.short_name}-${var.role}-lvm-${format("%02d", count.index+1)}"
+    Name = "${var.short_name}-${var.role}-lvm-${format(var.count_format, count.index+1)}"
   }
 }
+
 
 resource "aws_instance" "instance" {
   ami = "${var.source_ami}"
@@ -39,13 +41,15 @@ resource "aws_instance" "instance" {
     volume_size = "${var.ebs_volume_size}"
   }
 
+
   tags {
-    Name = "${var.short_name}-${var.role}-${format("%02d", count.index+1)}"
+    Name = "${var.short_name}-${var.role}-${format(var.count_format, count.index+1)}"
     sshUser = "${var.ssh_username}"
     role = "${var.role}"
     dc = "${var.datacenter}"
   }
 }
+
 
 resource "aws_volume_attachment" "instance-lvm-attachment" {
   count = "${var.count}"
@@ -54,8 +58,6 @@ resource "aws_volume_attachment" "instance-lvm-attachment" {
   volume_id = "${element(aws_ebs_volume.ebs.*.id, count.index)}"
   force_detach = true
 }
-
-
 
 
 output "ec2_ids" {

--- a/terraform/aws/instance/main.tf
+++ b/terraform/aws/instance/main.tf
@@ -60,6 +60,8 @@ resource "aws_volume_attachment" "instance-lvm-attachment" {
 }
 
 
+
+
 output "ec2_ids" {
   value = "${join(\",\", aws_instance.instance.*.id)}"
 }


### PR DESCRIPTION
This resolves https://github.com/CiscoCloud/mantl/issues/1277

- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

