### PR TITLE
allow alt dns names for certs

### DIFF
--- a/docs/security/security_setup.rst
+++ b/docs/security/security_setup.rst
@@ -18,6 +18,8 @@ If not present, ``security-setup`` will create a root CA to generate
 certificates from. If you want to use your own CA, add the key in
 ``ssl/private/cakey.pem`` and the cert in ``ssl/cacert.pem``.
 
+If you are getting X509 errors that the url requested was example.com but the certificate is for *.node.consul or a similar mis-match, you may need to add alternate SAN names when generating the certificate.  run security-setup --dns_alt_cert_names_string "alternative SAN names for cert here"
+
 If you have your own (self)signed certificates, you can put them in
 ``ssl/private/your.key.pem`` and ``ssl/certs/your.cert.pem``. Just override the
 locations the script generates (for example the consul key and cert would be

--- a/security-setup
+++ b/security-setup
@@ -153,6 +153,10 @@ cert_opts.add_argument(
     '--no-verify-certificates',
     action='store_true',
     help='skip verifying certificates as part of setup process')
+cert_opts.add_argument(
+    '--dns-alt-cert-names-string',
+    default='',
+    help='extra dns names or ip as a comma separated string to pass to cert generation, eg "DNS:localhost,IP:1.1.1.1"')
 
 # mantlui
 mantlui_opts = parser.add_argument_group(
@@ -465,9 +469,13 @@ class Component(object):
         with self.modify_security() as config:
 	    consul_dns_domain = config['consul_dns_domain']
 
-	common = "server.%s" % consul_dns_domain
-	san = dict(SAN='DNS:localhost,DNS:*.node.' + consul_dns_domain + ',DNS:*.service.' + consul_dns_domain + ',IP:127.0.0.1')
-
+        if self.args.dns_alt_cert_names_string:
+            dns_alt_cert_names_string = "," + self.args.dns_alt_cert_names_string
+        else:
+            dns_alt_cert_names_string = ""
+        common = "server.%s" % consul_dns_domain
+    	san = dict(SAN='DNS:localhost,DNS:*.node.' + consul_dns_domain + 
+                  ',DNS:*.service.' + consul_dns_domain + ',IP:127.0.0.1' + dns_alt_cert_names_string )
         with self.chdir(CERT_PATH):
             if posixpath.exists(key):
                 print('{} key already exists'.format(name))


### PR DESCRIPTION
modifies security-setup to allow passing --dns_alt_cert_names_string
in SAN format to include extra names in cert such as wildcards.

- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes

