### PR TITLE
Feature/granular zk hosts

### DIFF
--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -4,9 +4,12 @@ marathon_package: "marathon-{{ marathon_version }}"
 
 marathon_zk_auth: "{% if zk_marathon_user_secret is defined %}{{ zk_marathon_user }}:{{ zk_marathon_user_secret }}@{% endif %}"
 marathon_zk_dns: "zookeeper.service.{{ consul_dns_domain }}"
+marathon_zk_hosts: "{% for host in groups[zookeeper_server_group] %}{{ host }}:{{mesos_zk_port}}{% if not loop.last %},{% endif %}{% endfor %}"
+
+
 marathon_zk_port: 2181
 marathon_zk_chroot: marathon
-marathon_zk_connect: "zk://{{ marathon_zk_auth}}{{ marathon_zk_dns }}:{{ marathon_zk_port }}/{{ marathon_zk_chroot }}"
+marathon_zk_connect: "zk://{{ marathon_zk_auth}}{{ marathon_zk_hosts }}/{{ marathon_zk_chroot }}"
 
 marathon_zk_acl_world: "world:anyone:cdrwa"
 marathon_zk_acl: "{% if zk_marathon_user_secret is defined %}digest:{{ zk_marathon_user }}:{{ zk_marathon_user_secret_digest}}:cdraw{% endif  %}"

--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -37,4 +37,4 @@ mesos_consul_refresh: "7s"
 marathon_consul_image: ciscocloud/marathon-consul
 marathon_consul_image_tag: 0.2
 mantl_api_image: ciscocloud/mantl-api
-mantl_api_image_tag: 0.1.8
+mantl_api_image_tag: 0.2.0

--- a/roles/marathon/templates/mesos-consul.json.j2
+++ b/roles/marathon/templates/mesos-consul.json.j2
@@ -1,6 +1,6 @@
 {
   "args": [
-    "--zk=zk://zookeeper.service.{{ consul_dns_domain }}:2181/mesos"{% if do_consul_ssl %},
+    "--zk=zk://{{ marathon_zk_hosts }}/mesos"{% if do_consul_ssl %},
     "--consul-ssl",
     "--consul-ssl-verify=false"{% endif %},
     "--mesos-ip-order=mesos,host",
@@ -21,4 +21,3 @@
   "cpus": 0.1,
   "mem": 128
 }
-

--- a/roles/marathon/templates/zk.j2
+++ b/roles/marathon/templates/zk.j2
@@ -1,1 +1,0 @@
-zk://{{ marathon_zk_auth }}{{ mesos_zk_dns }}:{{ mesos_zk_port }}/{{ mesos_zk_chroot }}

--- a/roles/mesos/README.rst
+++ b/roles/mesos/README.rst
@@ -97,7 +97,13 @@ You can use these variables to customize your Mesos installation.
 
    default: ``mantl``
 
+.. data:: mesos_zk_hosts
+   
+   A ZooKeeper connection string in the the ``host:mesos_zk_port`` format, generated from the hosts in ``zookeeper_server_group``. 
+
 .. data:: mesos_zk_dns
+
+   Consul DNS entries for ZooKeeper hosts.  
 
    default: ``zookeeper.service.consul``
 
@@ -106,6 +112,8 @@ You can use these variables to customize your Mesos installation.
    default: ``2181``
 
 .. data:: mesos_zk_chroot
+
+   ZooKeeper znode to use as a base for mesos data.
 
    default: ``mesos``
 

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -20,9 +20,10 @@ mesos_cluster: mantl
 
 mesos_zk_auth: "{% if zk_mesos_user_secret is defined %}{{ zk_mesos_user }}:{{ zk_mesos_user_secret }}@{% endif %}"
 mesos_zk_dns: "zookeeper.service.{{ consul_dns_domain }}"
+mesos_zk_hosts: "{% for host in groups[zookeeper_server_group] %}{{ host }}:{{mesos_zk_port}}{% if not loop.last %},{% endif %}{% endfor %}"
 mesos_zk_port: 2181
 mesos_zk_chroot: mesos
-mesos_zk: zk://{{ mesos_zk_auth }}{{ mesos_zk_dns }}:{{ mesos_zk_port }}/{{ mesos_zk_chroot }}
+mesos_zk: "zk://{{ mesos_zk_auth }}{{ mesos_zk_hosts }}/{{ mesos_zk_chroot }}"
 mesos_leaders_group: role=control
 
 mesos_zk_acl_world: "world:anyone:r"

--- a/roles/mesos/tasks/nginx-proxy.yml
+++ b/roles/mesos/tasks/nginx-proxy.yml
@@ -9,6 +9,7 @@
 
 - name: configure nginx
   sudo: yes
+  run_once: yes
   command: consul-cli kv-write --token={{ consul_acl_secure_token }} secure/service/nginx/templates/mesos-leader @/etc/mesos-leader.nginx
   tags:
     - mesos

--- a/sample.yml
+++ b/sample.yml
@@ -44,6 +44,7 @@
   gather_facts: no
   vars:
     mesos_mode: follower
+    zookeeper_server_group: role=control
   roles:
     - mesos
 


### PR DESCRIPTION
Due to stability & split brain issues we see in mesos, we are moving away from using round-robins dns in consul for mesos zookeeper clients. This updates the mesos zk connection string to enumerate the hosts in `zookeeper_server_group`


- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes