### PR TITLE
Feature/zk purge logs

### DIFF
--- a/roles/zookeeper/README.rst
+++ b/roles/zookeeper/README.rst
@@ -65,3 +65,15 @@ You can use these variables to customize your ZooKepeer installation.
    Log level for ZooKeeper
 
    default: ``WARN``
+
+.. data::  zookeeper_log_retain_count 
+   
+   Number of zookeeper transaction logs and snapshots to keep.
+
+   default: ``3``
+
+.. data:: zookeeper_log_purge_interval
+
+   Interval in hours that zookeeper waits to purge transacton logs and snapshots. 
+
+   default: ``12``

--- a/roles/zookeeper/defaults/main.yml
+++ b/roles/zookeeper/defaults/main.yml
@@ -7,6 +7,7 @@ zookeeper_container_name: "{{ zookeeper_service }}"
 zookeeper_data_volume: "{{ zookeeper_service }}-data-volume"
 zookeeper_log_threshold: WARN
 
+
 # Allow larger than default maximum client connections.
 zookeeper_max_conns: 200
 
@@ -26,6 +27,11 @@ zookeeper_client_port: 2181
 zookeeper_server_ports: 2888:3888
 
 zookeeper_os_user: zookeeper
+
+#Log purging & intervals
+# Run every purge_interval hours, keep  retain_count copies
+zookeeper_log_retain_count: 3
+zookeeper_log_purge_interval: 12
 
 # Set the ZooKeeper ID
 zookeeper_server_group: role=control

--- a/roles/zookeeper/templates/zoo.cfg.j2
+++ b/roles/zookeeper/templates/zoo.cfg.j2
@@ -12,6 +12,11 @@ dataDir=/var/lib/zookeeper
 # the port at which the clients will connect
 clientPort={{ zookeeper_client_port }}
 
+# Log rotation/purging
+autopurge.snapRetainCount={{ zookeeper_log_retain_count }}
+autopurge.purgeInterval={{ zookeeper_log_purge_interval }}
+
+
 {% for host in groups[zookeeper_server_group]|sort %}
 server.{{ loop.index }}={{ hostvars[host]['inventory_hostname'] }}:{{ zookeeper_server_ports }}
 {% endfor %}


### PR DESCRIPTION
Adds the ability to purge zookeeper transaction and snapshot logs. This keeps filesystems from filling up on busy systems. 

- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes
