### PR TITLE
Add --ip option for mesos agents and master

### DIFF
--- a/roles/mesos/templates/mesos-agent.sysconfig.j2
+++ b/roles/mesos/templates/mesos-agent.sysconfig.j2
@@ -1,6 +1,7 @@
 # common configuration
 MESOS_PORT={{ mesos_follower_port }}
 MESOS_ADVERTISE_IP={{ private_ipv4 }}
+MESOS_IP={{ private_ipv4 }}
 MESOS_HOSTNAME={{ mesos_hostname | default(inventory_hostname + ".node." + consul_dns_domain) }}
 MESOS_LOG_DIR={{ mesos_log_dir }}
 MESOS_LOGGING_LEVEL={{ mesos_logging_level }}

--- a/roles/mesos/templates/mesos-master.sysconfig.j2
+++ b/roles/mesos/templates/mesos-master.sysconfig.j2
@@ -1,6 +1,7 @@
 # common configuration
 MESOS_PORT={{ mesos_leader_port }}
 MESOS_ADVERTISE_IP={{ private_ipv4 }}
+MESOS_IP={{ private_ipv4 }}
 MESOS_HOSTNAME={{ mesos_hostname | default(inventory_hostname + ".node." + consul_dns_domain) }}
 MESOS_LOG_DIR={{ mesos_log_dir }}
 MESOS_LOGGING_LEVEL={{ mesos_logging_level }}


### PR DESCRIPTION

- [ ] Installs cleanly on a fresh build of most recent master branch
- [ ] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes

This forces mesos to bind to the private IP of the instance