### PR TITLE
gitignore: don't check in terraform secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ ssl/serial*
 ssl/.rnd
 
 # terraform
+/*.tf
 **/*.tfstate*
 **/.terraform
 


### PR DESCRIPTION
This will ensure folks don't check in .tf files holding secrets. It only affects files in the project root directory, so it will still pick up modified files under `terraform/`.

- [x] Installs cleanly on a fresh build of most recent master branch (n/a)
- [x] Upgrades cleanly from the most recent release (n/a)
- [x] Updates documentation relevant to the changes (n/a)