### PR TITLE
kafka role

### DIFF
--- a/addons/kafka.yml
+++ b/addons/kafka.yml
@@ -1,0 +1,11 @@
+# Install the Kafka Mesos framework and start brokers. Run this playbook after
+# running the core playbook # (sample.yml)
+
+# CHECK SECURITY - when customizing you should leave this in. If you take it out
+# and forget to specify security.yml, security could be turned off on components
+# in your cluster!
+- include: "{{ playbook_dir }}/../playbooks/check-requirements.yml"
+
+- hosts: role=control
+  roles:
+    - kafka

--- a/roles/kafka/README.rst
+++ b/roles/kafka/README.rst
@@ -88,6 +88,12 @@ Variables
 
    default: 4096
 
+.. data:: kafka_broker_port
+
+   The port to bind to for the Kafka brokers.
+
+   default: 9092
+
 .. data:: kafka_broker_options
 
    The Kafka options to pass to the brokers.

--- a/roles/kafka/README.rst
+++ b/roles/kafka/README.rst
@@ -1,0 +1,101 @@
+Kafka
+======
+
+.. versionadded:: 1.1
+
+This role installs the `Kafka Mesos Framework <https://github.com/mesos/kafka>`_
+and starts Kafka brokers.
+
+Installation
+------------
+
+After a successful initial run (from your customized ``sample.yml``), you can
+install Kafka with ``ansible-playbook -e @security.yml addons/kafka.yml``. It
+can take several minutes for all components to deploy and become healthy.
+
+Accessing the Kafka Mesos REST API
+----------------------------------
+
+After the Kafka framework and the Kafka brokers have been successfully started
+and initialized, it should be possible to access the Kafka Mesos REST API at
+``/kafka`` on control nodes.
+
+Default Configuration
+---------------------
+
+The default configuration of the Kafka brokers will require at least 3 worker
+nodes that each have at least 4 CPUs and 4 GBs of memory available to Mesos.
+
+Depending on your planned environment, you may wish to customize the sizing of
+your Kafka cluster using the variables documented below.
+
+Customizing your Installation
+-----------------------------
+
+The size of your Kafka cluster is controlled by the variables documented below.
+
+Variables
+---------
+
+.. data:: kafka_scheduler_name
+
+   The application ID of the Kafka scheduler in Marathon.
+
+   default: "mantl/kafka"
+
+.. data:: kafka_service_name
+
+   The name of the service that is registered in Consul when the framework is
+   deployed. This needs to match what would be derived via mesos-consul. For
+   example, when ``kafka_scheduler_name`` is set to ``mantl/kafka``, the service
+   name should be ``kafka-mantl``.
+
+   default: "kafka-mantl"
+
+.. data:: kafka_scheduler_cpu
+
+   The amount of CPU to allocate to the Kafka scheduler instance (MB).
+
+   default: 0.2
+
+.. data:: kafka_scheduler_mem
+
+   The amount of memory to allocate to the Kafka scheduler instance (MB).
+
+   default: 512
+
+.. data:: kafka_broker_count
+
+   The number of Kafka brokers to start.
+
+   default: 3
+
+.. data:: kafka_broker_cpu
+
+   The amount of CPU to allocate to each Kafka broker.
+
+   default: 4
+
+.. data:: kafka_broker_mem
+
+   The amount of memory to allocate to each Kafka broker (MB).
+
+   default: 4096
+
+.. data:: kafka_broker_heap
+
+   The amount of heap to allocate to each Kafka broker (MB).
+
+   default: 4096
+
+.. data:: kafka_broker_options
+
+   The Kafka options to pass to the brokers.
+
+   default: "log.flush.interval.ms=10000,num.recovery.threads.per.data.dir=1,delete.topic.enable=true,log.index.size.max.bytes=10485760,num.partitions=8,num.network.threads=3,socket.request.max.bytes=104857600,log.segment.bytes=536870912,log.cleaner.enable=true,zookeeper.connection.timeout.ms=1000000,log.flush.scheduler.interval.ms=2000,log.retention.hours=72,log.flush.interval.messages=20000,log.dirs=/mantl/a/dfs-data/kafka-logs\\,/mantl/b/dfs-data/kafka-logs\\,/mantl/c/dfs-data/kafka-logs\\,/mantl/d/dfs-data/kafka-logs\\,/mantl/e/dfs-data/kafka-logs\\,/mantl/f/dfs-data/kafka-logs,log.index.interval.bytes=4096,socket.receive.buffer.bytes=1048576,min.insync.replicas=2,replica.lag.max.messages=10000000,replica.lag.time.max.ms=1000000,log.retention.check.interval.ms=3600000,message.max.bytes=20480,default.replication.factor=2,zookeeper.session.timeout.ms=500000,num.io.threads=8,auto.create.topics.enable=false,socket.send.buffer.bytes=1048576"
+
+.. data:: kafka_broker_jvm_options
+
+   The Kafka JVM options to pass to the brokers.
+
+   default: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -7,7 +7,7 @@ kafka_scheduler_mem: 512
 # Configuration for kafka brokers
 kafka_broker_count: 3
 kafka_brokers: "1..{{ kafka_broker_count }}"
-kafka_broker_cpu: 4
+kafka_broker_cpu: 1
 kafka_broker_mem: 4096
 kafka_broker_heap: 4096
 kafka_broker_port: 9092

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+kafka_scheduler_name: mantl/kafka
+kafka_service_name: kafka-mantl
+kafka_scheduler_cpu: 0.2
+kafka_scheduler_mem: 512
+
+# Configuration for kafka brokers
+kafka_broker_count: 3
+kafka_brokers: "1..{{ kafka_broker_count }}"
+kafka_broker_cpu: 4
+kafka_broker_mem: 4096
+kafka_broker_heap: 4096
+
+kafka_broker_options: "log.flush.interval.ms=10000,num.recovery.threads.per.data.dir=1,delete.topic.enable=true,log.index.size.max.bytes=10485760,num.partitions=8,num.network.threads=3,socket.request.max.bytes=104857600,log.segment.bytes=536870912,log.cleaner.enable=true,zookeeper.connection.timeout.ms=1000000,log.flush.scheduler.interval.ms=2000,log.retention.hours=72,log.flush.interval.messages=20000,log.dirs=/mantl/a/dfs-data/kafka-logs\\,/mantl/b/dfs-data/kafka-logs\\,/mantl/c/dfs-data/kafka-logs\\,/mantl/d/dfs-data/kafka-logs\\,/mantl/e/dfs-data/kafka-logs\\,/mantl/f/dfs-data/kafka-logs,log.index.interval.bytes=4096,socket.receive.buffer.bytes=1048576,min.insync.replicas=2,replica.lag.max.messages=10000000,replica.lag.time.max.ms=1000000,log.retention.check.interval.ms=3600000,message.max.bytes=20480,default.replication.factor=2,zookeeper.session.timeout.ms=500000,num.io.threads=8,auto.create.topics.enable=false,socket.send.buffer.bytes=1048576"
+
+kafka_broker_jvm_options: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
+
+kafka_brokers_configuration: "broker={{kafka_brokers}}&cpus={{kafka_broker_cpu}}&mem={{kafka_broker_mem}}&heap={{kafka_broker_heap}}&options={{kafka_broker_options}}&jvmOptions={{kafka_broker_jvm_options}}"
+
+kafka_brokers_start: "broker={{kafka_brokers}}"

--- a/roles/kafka/defaults/main.yml
+++ b/roles/kafka/defaults/main.yml
@@ -10,11 +10,12 @@ kafka_brokers: "1..{{ kafka_broker_count }}"
 kafka_broker_cpu: 4
 kafka_broker_mem: 4096
 kafka_broker_heap: 4096
+kafka_broker_port: 9092
 
 kafka_broker_options: "log.flush.interval.ms=10000,num.recovery.threads.per.data.dir=1,delete.topic.enable=true,log.index.size.max.bytes=10485760,num.partitions=8,num.network.threads=3,socket.request.max.bytes=104857600,log.segment.bytes=536870912,log.cleaner.enable=true,zookeeper.connection.timeout.ms=1000000,log.flush.scheduler.interval.ms=2000,log.retention.hours=72,log.flush.interval.messages=20000,log.dirs=/mantl/a/dfs-data/kafka-logs\\,/mantl/b/dfs-data/kafka-logs\\,/mantl/c/dfs-data/kafka-logs\\,/mantl/d/dfs-data/kafka-logs\\,/mantl/e/dfs-data/kafka-logs\\,/mantl/f/dfs-data/kafka-logs,log.index.interval.bytes=4096,socket.receive.buffer.bytes=1048576,min.insync.replicas=2,replica.lag.max.messages=10000000,replica.lag.time.max.ms=1000000,log.retention.check.interval.ms=3600000,message.max.bytes=20480,default.replication.factor=2,zookeeper.session.timeout.ms=500000,num.io.threads=8,auto.create.topics.enable=false,socket.send.buffer.bytes=1048576"
 
 kafka_broker_jvm_options: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
 
-kafka_brokers_configuration: "broker={{kafka_brokers}}&cpus={{kafka_broker_cpu}}&mem={{kafka_broker_mem}}&heap={{kafka_broker_heap}}&options={{kafka_broker_options}}&jvmOptions={{kafka_broker_jvm_options}}"
+kafka_brokers_configuration: "broker={{kafka_brokers}}&cpus={{kafka_broker_cpu}}&mem={{kafka_broker_mem}}&heap={{kafka_broker_heap}}&port={{kafka_broker_port}}&options={{kafka_broker_options}}&jvmOptions={{kafka_broker_jvm_options}}"
 
 kafka_brokers_start: "broker={{kafka_brokers}}"

--- a/roles/kafka/tasks/main.yml
+++ b/roles/kafka/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+- name: create packages json
+  sudo: yes
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - src: kafka.json.j2
+      dest: /etc/marathon/apps/kafka.json
+  tags:
+    - kafka
+
+- name: check if kafka service is registered
+  sudo: yes
+  run_once: yes
+  shell: "consul-cli catalog-service {{ kafka_service_name }} | jq '.|length'"
+  register: kafka_service_count
+  changed_when: false
+  tags:
+    - kafka
+
+- name: install kafka
+  sudo: yes
+  run_once: yes
+  command: consul-cli kv-write mantl-install/apps/kafka @/etc/marathon/apps/kafka.json
+  when: kafka_service_count.stdout|int == 0
+  tags:
+    - kafka
+
+- name: create kafka broker script
+  sudo: yes
+  template:
+    src: kafka-brokers.sh.j2
+    dest: /usr/local/bin/kafka-brokers.sh
+    mode: 0755
+  tags:
+    - kafka
+
+- name: start kafka brokers
+  sudo: yes
+  run_once: yes
+  command: /usr/local/bin/kafka-brokers.sh
+  tags:
+    - kafka
+
+- name: remove packages json
+  sudo: yes
+  file:
+    dest: item
+    state: absent
+  with_items:
+    - /etc/marathon/apps/kafka.json
+  tags:
+    - kafka

--- a/roles/kafka/templates/kafka-brokers.sh.j2
+++ b/roles/kafka/templates/kafka-brokers.sh.j2
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+max_wait=300
+svc={{ kafka_service_name }}
+
+while :; do
+    if [[ $(consul-cli health-checks $svc | jq -r '.[].Status') == 'passing' ]]; then
+        echo "Kafka scheduler is up and running"
+
+        api=$(consul-cli catalog-service $svc | jq -r '.[]|.ServiceAddress + ":" + (.ServicePort|tostring)')
+
+        # add brokers
+        curl -d "{{ kafka_brokers_configuration }}" http://$api/api/broker/add
+
+        # start brokers
+        curl -d "{{ kafka_brokers_start }}" http://$api/api/broker/start
+
+        exit 0
+    fi
+
+    if [ $SECONDS -gt $max_wait ]; then
+        echo "No healthy Kafka scheduler found in $max_wait seconds"
+        exit 1
+    fi
+
+    sleep 5
+done

--- a/roles/kafka/templates/kafka.json.j2
+++ b/roles/kafka/templates/kafka.json.j2
@@ -1,0 +1,12 @@
+{
+  "name": "kafka",
+  "config": {
+    "kafka": {
+      "app": {
+        "cpus": {{ kafka_scheduler_cpu }},
+        "mem": {{ kafka_scheduler_mem }}
+      },
+      "framework-name": "{{ kafka_scheduler_name }}"
+    }
+  }
+}

--- a/roles/mantlui/defaults/main.yml
+++ b/roles/mantlui/defaults/main.yml
@@ -1,4 +1,4 @@
 mantlui_nginx_image: ciscocloud/nginx-mantlui
-mantlui_nginx_image_tag: 0.6.7
+mantlui_nginx_image_tag: 0.6.8
 do_mantlui_ssl: false
 do_mantlui_auth: false


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

Installation documentation available in the role readme. Note that you will need at least 3 workers each with 1 CPU and 4 GB of memory available to Mesos in order to run with the default configuration.

This depends on https://github.com/CiscoCloud/nginx-mantlui/pull/18 being merged and the 0.6.8 tag of ciscocloud/nginx-mantlui being pushed to docker hub.

After successful Kafka installation (it can take a few minutes), verify the following:

- that the mantl/kafka scheduler is running and healthy in Marathon
- that there are 3 Kafka brokers running in Mesos (broker-1, broker-2, broker-3)

Once the brokers are up, you should be able to produce and consume data. Here is one example of a manual test:

```shell
# create a topic
curl -sku admin:password -d "topic=journal" https://control-node-01/kafka/api/topic/add

# on one node, pipe journald logs into the journal kafka topic
sudo journalctl -f | sudo docker run --rm -i ryane/kafkacat -b broker-1.service.consul:9092,broker-2.service.consul:9092,broker-3.service.consul:9092 -t journal -z snappy

# on another node, consume the events from the  journal topic
sudo docker run --rm -it ryane/kafkacat -b broker-1.service.consul:9092,broker-2.service.consul:9092,broker-3.service.consul:9092 -t journal
```