### PR TITLE
add sleep_control playbook

### DIFF
--- a/library/ec2_remote_facts.py
+++ b/library/ec2_remote_facts.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python
+#
+# This is a free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This Ansible library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: ec2_remote_facts
+short_description: Gather facts about ec2 instances in AWS
+description:
+    - Gather facts about ec2 instances in AWS
+version_added: "2.0"
+options:
+  filters:
+    description:
+      - A dict of filters to apply. Each dict item consists of a filter key and a filter value. See U(http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html) for possible filters.
+    required: false
+    default: null
+author:
+    - "Michael Schuett (@michaeljs1990)"
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+# Gather facts about all ec2 instances
+- ec2_remote_facts:
+
+# Gather facts about all running ec2 instances with a tag of Name:Example
+- ec2_remote_facts:
+    filters:
+      instance-state-name: running
+      "tag:Name": Example
+
+# Gather facts about instance i-123456
+- ec2_remote_facts:
+    filters:
+      instance-id: i-123456
+
+# Gather facts about all instances in vpc-123456 that are t2.small type
+- ec2_remote_facts:
+    filters:
+      vpc-id: vpc-123456
+      instance-type: t2.small
+
+'''
+
+try:
+    import boto.ec2
+    from boto.exception import BotoServerError
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+def get_instance_info(instance):
+
+    # Get groups
+    groups = []
+    for group in instance.groups:
+        groups.append({ 'id': group.id, 'name': group.name }.copy())
+
+    # Get interfaces
+    interfaces = []
+    for interface in instance.interfaces:
+        interfaces.append({ 'id': interface.id, 'mac_address': interface.mac_address }.copy())
+
+    # If an instance is terminated, sourceDestCheck is no longer returned
+    try:
+        source_dest_check = instance.sourceDestCheck
+    except AttributeError:
+        source_dest_check = None
+
+    instance_info = { 'id': instance.id,
+                    'kernel': instance.kernel,
+                    'instance_profile': instance.instance_profile,
+                    'root_device_type': instance.root_device_type,
+                    'private_dns_name': instance.private_dns_name,
+                    'public_dns_name': instance.public_dns_name,
+                    'ebs_optimized': instance.ebs_optimized,
+                    'client_token': instance.client_token,
+                    'virtualization_type': instance.virtualization_type,
+                    'architecture': instance.architecture,
+                    'ramdisk': instance.ramdisk,
+                    'tags': instance.tags,
+                    'key_name': instance.key_name,
+                    'source_destination_check': source_dest_check,
+                    'image_id': instance.image_id,
+                    'groups': groups,
+                    'interfaces': interfaces,
+                    'spot_instance_request_id': instance.spot_instance_request_id,
+                    'requester_id': instance.requester_id,
+                    'monitoring_state': instance.monitoring_state,
+                    'placement': {
+                                  'tenancy': instance._placement.tenancy,
+                                  'zone': instance._placement.zone
+                                 },
+                    'ami_launch_index': instance.ami_launch_index,
+                    'launch_time': instance.launch_time,
+                    'hypervisor': instance.hypervisor,
+                    'region': instance.region.name,
+                    'persistent': instance.persistent,
+                    'private_ip_address': instance.private_ip_address,
+                    'state': instance._state.name,
+                    'vpc_id': instance.vpc_id,
+                  }
+
+    return instance_info
+
+
+def list_ec2_instances(connection, module):
+
+    filters = module.params.get("filters")
+    instance_dict_array = []
+
+    try:
+        all_instances = connection.get_only_instances(filters=filters)
+    except BotoServerError as e:
+        module.fail_json(msg=e.message)
+
+    for instance in all_instances:
+        instance_dict_array.append(get_instance_info(instance))
+
+    module.exit_json(instances=instance_dict_array)
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            filters = dict(default=None, type='dict')
+        )
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec)
+
+    if not HAS_BOTO:
+        module.fail_json(msg='boto required for this module')
+
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
+
+    if region:
+        try:
+            connection = connect_to_aws(boto.ec2, region, **aws_connect_params)
+        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError), e:
+            module.fail_json(msg=str(e))
+    else:
+        module.fail_json(msg="region must be specified")
+
+    list_ec2_instances(connection, module)
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+if __name__ == '__main__':
+    main()
+

--- a/playbooks/aws/sleep_control.yml
+++ b/playbooks/aws/sleep_control.yml
@@ -1,0 +1,326 @@
+---
+
+# WARNING: This playbook should really not be run without elastic ips.  However, we can't make vars_prompt conditional.
+# Uncomment this block if you want to enable the protection
+
+  # hosts: localhost
+  # vars_prompt:
+  #   - name: confirm_reboot 
+  #     prompt: "Running reboot-hosts without elastic ips will likely break things.  Enter to continue.  Type no to abort"
+  #     default: "yes"
+  # tasks:
+  # - name: abort if not confirmed 
+  #   fail: msg="aborting as per request"
+  #   when: confirm_reboot != 'yes'
+
+# This playbook is intended to reduce costs and save energy by allowing mantl clusters to be put to sleep indefinitely or on a cron cycle.
+# It's useful for devs working on mantl who don't want to destroy a WIP cluster but won't be touching it while they sleep or over the 
+# weekend.  A stack with a few m4.xlarge's could cost 2k per month, so one could be saving upwards of $700 per month.  Although you still 
+# pay for eips, block storage etc, typically the running instance cost is 90% of the bill.
+
+# By default, we will leave the control nodes alone.  They are the central nervous system of the cluster.
+# This is similar to how humans sleep.  The workers (musculo skeletal system) and edge nodes (eyes, ears..)
+# shut down but the CNS stays working.  Over-ride with -e do_sleep_controllers=yes
+
+# This play is also useful for testing resilience of the cluster regularly and forces users to run stateless containers backed by proper 
+# distributed stores like cassandra or mongo.
+
+# We support two workflows.  One where a cron/chronos job runs this script occasionally (wip)
+# and puts servers to sleep or wakes them depneding on preset values.
+# The second case is to set a server to sleep/wake on demand.
+
+# You may use override_tags=yes or tag instances with tag name sleep_control and tag values in
+# ['dreamer', 'never','timed']
+# dreamer -> put to sleep when this playbook runs
+# never -> never put to sleep (allows switching default to dreamer)
+# timed -> requires sleep_time and wake_time in UTC 24 hr clock set in hostvars
+# handle with chronos cron job
+
+# Note, this is essentially the same as reboot-hosts.yml but is much more complicated because
+# if servers are shut down you cannot ssh to them.  You must communicate by running against
+# localhost and looping over a list of servers talking to the aws api.
+
+
+############################################################
+# Refresh terraform to get running instances updated
+############################################################
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: refresh terraform
+    local_action: shell chdir=../../ pwd && terraform refresh -target=module.route53 -target=module.control-nodes -target=module.worker-nodes -target=module.edge-nodes
+
+#############################################################
+# Group by instance_state before we jump in serial mode
+#############################################################
+
+- hosts: all
+  gather_facts: no
+  tasks:
+
+  - name: create group of running instances
+    group_by: 
+      key: "{{ instance_state }}"
+
+  - set_fact:
+      consul_nodes: "{{ ( (groups['role=worker'] | default([])) + (groups['role=control'] | default([])) + (groups['role=edge']) | default([])) }}"
+    run_once: yes
+
+  - name: get the ec2_tags 
+    local_action:
+      module: ec2_tag
+      resource: "{{ hostvars[item]['id'] }}" 
+      state: list
+      region: "{{ region }}"
+      ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+    with_items: "{{ consul_nodes | list }}"
+    register: register_ec2_tag
+    run_once: yes  
+
+###############################
+# Shutdown block
+###############################
+
+- hosts: running
+  serial: 1
+  gather_facts: no
+  vars:
+    # Passing override_tags=yes allows forcing sleep/wake against their tags.
+    default_sleep_control: 'never'
+    override_tags: 'no'
+    # pass -e do_sleep=no to skip putting to sleep block
+    do_sleep: 'yes'
+    # pass -e do_wake=no to only put to sleep without waking
+    do_wake: 'yes'
+    # normally you don't want to shut down the controllers.  They are the Central Nervous System
+    do_sleep_controllers: 'no'
+
+  tasks:
+  - name: set consul maintenance enable
+    command: consul maint -enable -reason "{{ lookup('env', 'USER') }} initiated sleep"
+    register: register_consul_maint
+    when: ( ('aws_tag_sleep_control' in groups) and (inventory_hostname in groups['aws_tag_sleep_control=dreamer'] ) ) or ( override_tags != 'no' )   and ( do_sleep == 'yes' ) and ( inventory_hostname not in groups['role=control'] )
+    failed_when: "{{ (register_consul_maint.rc != 0 ) and ( register_consul_maint.stdout.find('Error querying Consul agent') == -1 ) }}"
+    when: inventory_hostname not in groups['role=bastion']
+
+  - name: stop host on non-control hosts
+    local_action:
+      module: ec2 
+      instance_ids: "{{ id }}"
+      state: stopped
+      region: "{{ region }}"
+      ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+      wait: yes
+    when: ( ('aws_tag_sleep_control' in groups) and (inventory_hostname in groups['aws_tag_sleep_control=dreamer'] ) ) or ( override_tags != 'no' )   and ( do_sleep == 'yes' ) and ( inventory_hostname not in groups['role=control'] )
+
+  - name: optionally stop host on control hosts
+    local_action:
+      module: ec2 
+      instance_ids: "{{ id }}"
+      state: stopped
+      region: "{{ region }}"
+      ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+      wait: yes
+    when: ( ('aws_tag_sleep_control' in groups) and (inventory_hostname in groups['aws_tag_sleep_control=dreamer'] ) ) or ( override_tags != 'no' )   and ( do_sleep == 'yes' ) and (do_sleep_controllers == 'yes')
+
+###############################
+# Startup block
+###############################
+
+# Looping against localhost is naturally serialized, just add pause if needed
+
+- hosts: localhost
+  gather_facts: no
+  vars:
+    do_wake: 'yes'
+    do_sleep: 'yes'
+    default_sleep_control: 'never'
+    override_tags: 'no'
+    do_restart_consul: 'no'
+    do_sleep_controllers: 'no'
+  tasks:
+
+  - set_fact:
+      consul_nodes: "{{ ( (groups['role=worker'] | default([])) + (groups['role=control'] | default([])) + (groups['role=edge']) | default([])) }}"
+    run_once: yes
+
+  - name: get the ec2_tags before starting
+    local_action:
+      module: ec2_tag
+      resource: "{{ hostvars[item]['id'] }}" 
+      state: list
+      region: "{{ region }}"
+      ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+    with_items: "{{ consul_nodes | list }}"
+    register: register_ec2_tag
+    run_once: yes  
+
+  - name: start host for control nodes
+    local_action:
+      module: ec2 
+      instance_ids: "{{ hostvars[item]['id'] }}"
+      state: 'running'
+      region: "{{ region }}"
+      ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+      wait: yes
+    with_items: "{{ consul_nodes | list }}"
+    when: ( ('aws_tag_sleep_control' in groups) and ( item in groups['aws_tag_sleep_control=dreamer'] )  or ( override_tags != 'no' ) ) and ( do_wake == 'yes' ) and ( item in groups['role=control'] )
+
+  - name: start host for non-control nodes
+    local_action:
+      module: ec2 
+      instance_ids: "{{ hostvars[item]['id'] }}"
+      state: 'running'
+      region: "{{ region }}"
+      ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+      wait: yes
+    with_items: "{{ consul_nodes | list }}"
+    when: ( ('aws_tag_sleep_control' in groups) and ( item in groups['aws_tag_sleep_control=dreamer'] )  or ( override_tags != 'no' ) ) and ( do_wake == 'yes' ) and ( item not in groups['role=control'] )
+
+  - name: wait for host boot on tagged servers
+    local_action:
+      module: wait_for
+      host: "{{ hostvars[item]['ansible_ssh_host'] }}"
+      port: 22
+      search_regex: OpenSSH
+      delay: 1
+      timeout: 300
+      state: started
+    with_items: "{{ groups['aws_tag_sleep_control=dreamer'] | list) }}"
+    when:  (do_wake == 'yes') and ('aws_tag_sleep_control' in groups) and ( item in groups['aws_tag_sleep_control=dreamer'] )
+
+  - name: wait for over-ridden host boot
+    local_action:
+      module: wait_for
+      host: "{{ hostvars[item]['ansible_ssh_host'] }}"
+      port: 22
+      search_regex: OpenSSH
+      delay: 1
+      timeout: 300
+      state: started
+    with_items: "{{ consul_nodes | list }}"
+    when: ( override_tags != 'no' ) and ( do_wake == 'yes' )
+
+    ##########################################
+    # Startup block: clean up raft/peers.json
+    ##########################################
+
+# var needed for peers.json
+# hopefully this can be removed when mantl moves to ansible 2.0
+# exec_main flag https://github.com/ansible/proposals/pull/4
+  - include_vars: ../../roles/consul/defaults/main.yml
+
+# according to https://www.consul.io/docs/guides/outage.html
+# https://github.com/ansible/ansible/issues/10375
+# outage in depth https://sitano.github.io/2015/10/06/abt-consul-outage/
+  - name: stop consul 
+    shell: systemctl stop consul
+    become: yes
+    delegate_to: "{{ item }}"
+    with_items: "{{ groups['role=control'] }}"
+    when: ( do_restart_consul == 'yes' ) or ( do_sleep_controllers == 'yes' )
+
+  - name: template raft/peers.json to replace null from graceful shutdown 
+    template: 
+      src: ../../roles/consul/templates/peers.json.j2
+      dest: /var/lib/consul/raft/peers.json
+    delegate_to: "{{ item }}"
+    with_items: "{{ groups['role=control'] }}"
+    become: yes
+
+  - name: start consul 
+    shell: systemctl start consul
+    become: yes
+    delegate_to: "{{ item }}"
+    with_items: "{{ groups['role=control'] }}"
+    when: ( do_restart_consul == 'yes' ) or ( do_sleep_controllers == 'yes' )
+
+###############################
+# Regroup running instances
+###############################
+
+- hosts: localhost
+# refresh terraform to get running instances
+  vars:
+    do_wake: 'yes'
+    do_sleep: 'yes'
+    default_sleep_control: 'never'
+    override_tags: 'no'
+  tasks:
+  - set_fact:
+      consul_nodes: "{{ ( (groups['role=worker'] | default([])) + (groups['role=control'] | default([])) + (groups['role=edge']) | default([])) }}"
+
+  - name: get the ec2_tags before starting
+    local_action:
+      module: ec2_tag
+      resource: "{{ hostvars[item]['id'] }}" 
+      state: list
+      region: "{{ region }}"
+      ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+    with_items: "{{ consul_nodes | list }}"
+    register: register_ec2_tag
+    run_once: yes  
+
+  - name: refresh terraform after stopping
+    local_action: shell chdir=../../ pwd && terraform refresh -target=module.route53 -target=module.control-nodes -target=module.worker-nodes -target=module.edge-nodes
+
+  - set_fact:
+      consul_nodes: "{{ ( (groups['role=worker'] | default([])) + (groups['role=control'] | default([])) + (groups['role=edge']) | default([])) }}"
+
+  - name: create group of running instances after stopping
+    local_action:
+      module: group_by
+      key: "{{ hostvars[item]['instance_state'] }}"
+    with_items: "{{ consul_nodes }}"
+
+###############################
+# Disable maintenance mode on consul running instances
+###############################
+
+- hosts: running
+  serial: 1
+  vars:
+    do_wake: 'yes'
+    do_sleep: 'yes'
+    default_sleep_control: 'never'
+  pre_tasks:
+
+  - name: wait for consul to listen
+    wait_for:
+      port: 8500
+    when: do_wake == 'yes'
+
+  - name: set consul maintenance disable
+    command: consul maint -disable
+    when: do_wake == 'yes'
+
+  - name: pause for rolling reboot
+    pause:
+      seconds: 3
+
+
+#################################
+# restart non-persistent services
+#################################
+
+  - name: reload nginx-mantlui
+    sudo: yes
+    command: systemctl restart nginx-mantlui
+    tags:
+      - mantlui
+    when: ( do_wake == 'yes' ) and ( inventory_hostname in groups['role=control'] )
+
+  - debug: msg="Now run ansible-playbook -e @security.yml mantl.yml --tags mantlui"  
+    run_once: yes
+# TODO Broken until this is resolved https://github.com/CiscoCloud/mantl/issues/1343#issuecomment-209117859
+  # roles:
+  #   - mantlui
+

--- a/playbooks/aws/sleep_control_static.yml
+++ b/playbooks/aws/sleep_control_static.yml
@@ -1,0 +1,411 @@
+---
+
+# WARNING: This playbook should really not be run without elastic ips.  However, we can't make vars_prompt conditional.
+# Uncomment this block if you want to enable the protection
+
+# This version of sleep_control relies on ansible only (no terraform) and a 
+# static hosts file.
+# By default ansible ec2.py inventory only returns running instances 
+# You will need to modify ec2.ini as follows
+# all_instances = True
+
+# and set EC2_INI_PATH env var to find it.
+
+# This playbook requires ec2_tags['Name'] == inventory_hostname
+
+# Required vars
+# region 
+# vpc_id
+
+# Usage (example to put hosts to sleep )
+# ansible-playbook -i /path/to/hosts 
+#             playbooks/aws/sleep_control.yml  
+#             -e do_wake=no 
+#             -e override_tags=yes 
+#             -e do_restart_consul=no 
+
+  # hosts: localhost
+  # vars_prompt:
+  #   - name: confirm_reboot 
+  #     prompt: "Running reboot-hosts without elastic ips will likely break things.  Enter to continue.  Type no to abort"
+  #     default: "yes"
+  # tasks:
+  # - name: abort if not confirmed 
+  #   fail: msg="aborting as per request"
+  #   when: confirm_reboot != 'yes'
+
+# This playbook is intended to reduce costs and save energy by allowing mantl clusters to be put to sleep indefinitely or on a cron cycle.
+# It's useful for devs working on mantl who don't want to destroy a WIP cluster but won't be touching it while they sleep or over the 
+# weekend.  A stack with a few m4.xlarge's could cost 2k per month, so one could be saving upwards of $700 per month.  Although you still 
+# pay for eips, block storage etc, typically the running instance cost is 90% of the bill.
+
+# By default, we will leave the control nodes alone.  They are the central nervous system of the cluster.
+# This is similar to how humans sleep.  The workers (musculo skeletal system) and edge nodes (eyes, ears..)
+# shut down but the CNS stays working.  Over-ride with -e do_sleep_controllers=yes
+
+# This play is also useful for testing resilience of the cluster regularly and forces users to run stateless containers backed by proper 
+# distributed stores like cassandra or mongo.
+
+# We support two workflows.  One where a cron/chronos job runs this script occasionally (wip)
+# and puts servers to sleep or wakes them depneding on preset values.
+# The second case is to set a server to sleep/wake on demand.
+
+# You may use override_tags=yes or tag instances with tag name sleep_control and tag values in
+# ['dreamer', 'never','timed']
+# dreamer -> put to sleep when this playbook runs
+# never -> never put to sleep (allows switching default to dreamer)
+# timed -> requires sleep_time and wake_time in UTC 24 hr clock set in hostvars
+# handle with chronos cron job
+
+# Note, this is essentially the same as reboot-hosts.yml but is much more complicated because
+# if servers are shut down you cannot ssh to them.  You must communicate by running against
+# localhost and looping over a list of servers talking to the aws api.
+
+
+#############################################################
+# Group by instance_state before we jump in serial mode
+#############################################################
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: get ec2_remote_facts for servers in all states
+      ec2_remote_facts:
+        filters:
+          vpc-id: "{{vpc_id}}"
+        region: "{{ region }}"
+        ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+        ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+      register: register_ec2_remote_facts
+
+    - debug: msg="{{ register_ec2_remote_facts.instances }}"
+
+
+- hosts: all
+  gather_facts: no
+  tasks:
+    - set_fact: 
+       register_ec2_remote_facts: "{{ hostvars['localhost']['register_ec2_remote_facts'] }}"
+
+    - debug: msg="{{ inventory_hostname }}"
+
+    - debug: msg="{{ item['tags']['Name'] }}"
+      with_items: "{{ register_ec2_remote_facts['instances'] }}"
+      run_once: yes
+
+    - set_fact:
+        instance_state: "{{ item['state'] }}"
+      with_items: "{{ register_ec2_remote_facts['instances'] }}"
+      when: "{{ item['tags']['Name'] == inventory_hostname }}"
+
+    - name: group instances by instance state
+      group_by: 
+        key: "{{ instance_state }}"  
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: group instances by instance state
+      group_by: 
+        key: "{{ item.state }}"    
+      with_items: "{{ register_ec2_remote_facts.instances }}"
+
+    - debug: msg="{{groups}}"
+  
+# - hosts: localhost
+#   gather_facts: no
+#   tasks:
+#   - name: get the ec2_tags 
+#     local_action:
+#       module: ec2_tag
+#       resource: "{{ hostvars[item]['id'] }}" 
+#       state: list
+#       region: "{{ region }}"
+#       ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+#       ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+#     with_items: "{{ groups['all'] | list }}"
+#     register: register_ec2_tag
+#     run_once: yes  
+
+#  - debug: msg="{{register_ec2_tag}}"
+
+
+    - set_fact:
+        consul_nodes: "{{ ( (groups['role=worker'] | default([])) + (groups['role=control'] | default([])) + (groups['role=edge']) | default([])) }}"
+      run_once: yes
+
+
+###############################
+# Shutdown block
+###############################
+
+- hosts: running
+  serial: 1
+  gather_facts: yes
+  vars:
+    # Passing override_tags=yes allows forcing sleep/wake against their tags.
+    default_sleep_control: 'never'
+    override_tags: 'no'
+    # pass -e do_sleep=no to skip putting to sleep block
+    do_sleep: 'yes'
+    # pass -e do_wake=no to only put to sleep without waking
+    do_wake: 'yes'
+    # normally you don't want to shut down the controllers.  They are the Central Nervous System
+    do_sleep_controllers: 'no'
+
+  tasks:
+  - name: gather ec2 facts 
+    ec2_facts: 
+
+  - name: set instance_id fact 
+    set_fact: 
+      id: "{{ ansible_ec2_instance_id }}"
+    when: "{{ inventory_hostname != 'localhost' }}"
+     
+  - name: set private_ipv4 compatible with terraform.py inventory
+    set_fact:
+      private_ipv4: "{{ ansible_ec2_local_ipv4 }}"
+    when: "{{ inventory_hostname != 'localhost' }}"
+
+  - name: set consul maintenance enable
+    command: consul maint -enable -reason "{{ lookup('env', 'USER') }} initiated sleep"
+    register: register_consul_maint
+    when: ( ('aws_tag_sleep_control' in groups) and (inventory_hostname in groups['aws_tag_sleep_control=dreamer'] ) ) or ( override_tags != 'no' )   and ( do_sleep == 'yes' ) and ( inventory_hostname not in groups['role=control'] )
+    failed_when: "{{ (register_consul_maint.rc != 0 ) and ( register_consul_maint.stdout.find('Error querying Consul agent') == -1 ) }}"
+    when: inventory_hostname not in ( groups['role=bastion'] | default([]) ) and ( inventory_hostname != 'localhost' )
+
+  - name: stop host on non-control hosts
+    local_action:
+      module: ec2 
+      instance_ids: "{{ id }}"
+      state: stopped
+      region: "{{ region }}"
+      ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+      wait: yes
+    when: ( ('aws_tag_sleep_control' in groups) and (inventory_hostname in groups['aws_tag_sleep_control=dreamer'] ) ) or ( override_tags != 'no' )   and ( do_sleep == 'yes' ) and ( inventory_hostname not in (groups['role=control'] + ['localhost']) )
+
+  - name: optionally stop host on control hosts
+    local_action:
+      module: ec2 
+      instance_ids: "{{ id }}"
+      state: stopped
+      region: "{{ region }}"
+      ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+      wait: yes
+    when: ( ('aws_tag_sleep_control' in groups) and (inventory_hostname in groups['aws_tag_sleep_control=dreamer'] ) ) or ( override_tags != 'no' )   and ( do_sleep == 'yes' ) and (do_sleep_controllers == 'yes') and ( inventory_hostname != 'localhost')
+
+###############################
+# Startup block
+###############################
+
+# Looping against localhost is naturally serialized, just add pause if needed
+
+- hosts: localhost
+  gather_facts: no
+  vars:
+    do_wake: 'yes'
+    do_sleep: 'yes'
+    default_sleep_control: 'never'
+    override_tags: 'no'
+    do_restart_consul: 'no'
+    do_sleep_controllers: 'no'
+  tasks:
+
+  - set_fact:
+      consul_nodes: "{{ ( (groups['role=worker'] | default([])) + (groups['role=control'] | default([])) + (groups['role=edge']) | default([])) }}"
+    run_once: yes
+
+  - name: get ec2_remote_facts in startup block
+    ec2_remote_facts:
+      filters:
+        vpc-id: "{{vpc_id}}"
+      region: "{{ region }}"
+      ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+    register: register_ec2_remote_facts
+
+  - name: group instances by instance state in startup block
+    group_by: 
+      key: "{{ item['state'] }}"
+    with_items: "{{ register_ec2_remote_facts['instances'] }}" 
+
+  - name: start host for control nodes
+    local_action:
+      module: ec2 
+      instance_ids: "{{ item['id'] }}"
+      state: 'running'
+      region: "{{ region }}"
+      ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+      wait: yes
+    with_items: "{{ register_ec2_remote_facts['instances'] }}"
+    when: ( ('aws_tag_sleep_control' in groups) and ( item['tags']['Name'] in groups['aws_tag_sleep_control=dreamer'] )  or ( override_tags != 'no' ) ) and ( do_wake == 'yes' ) and ( item['tags']['Name'] in groups['role=control'] )
+
+  - name: start host for non-control nodes
+    local_action:
+      module: ec2 
+      instance_ids: "{{ item['id'] }}"
+      state: 'running'
+      region: "{{ region }}"
+      ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+      wait: yes
+    with_items: "{{ register_ec2_remote_facts['instances'] }}"
+    when: ( ('aws_tag_sleep_control' in groups) and ( item['tags']['Name'] in groups['aws_tag_sleep_control=dreamer'] )  or ( override_tags != 'no' ) ) and ( do_wake == 'yes' ) and ( item['tags']['Name'] not in groups['role=control'] )
+
+  - name: wait for host boot on tagged servers
+    local_action:
+      module: wait_for
+      host: "{{ item['private_ip_address'] }}"
+      port: 22
+      search_regex: OpenSSH
+      delay: 1
+      timeout: 300
+      state: started
+    with_items: "{{ register_ec2_remote_facts['instances'] }}"
+    when:  (do_wake == 'yes') and ((override_tags == 'yes') or and ('aws_tag_sleep_control' in groups) and ( item in groups['aws_tag_sleep_control=dreamer'] ) )
+
+  - name: wait for over-ridden host boot
+    local_action:
+      module: wait_for
+      host: "{{ hostvars[item]['private_ip_address'] }}"
+      port: 22
+      search_regex: OpenSSH
+      delay: 1
+      timeout: 300
+      state: started
+    with_items: "{{ register_ec2_remote_facts['instances'] }}"
+    when: ( override_tags != 'no' ) and ( do_wake == 'yes' ) and (inventory_hostname in "{{ consul_nodes | list }}")
+
+    ##########################################
+    # Startup block: clean up raft/peers.json
+    ##########################################
+
+# var needed for peers.json
+# hopefully this can be removed when mantl moves to ansible 2.0
+# exec_main flag https://github.com/ansible/proposals/pull/4
+  - include_vars: ../../roles/consul/defaults/main.yml
+
+# according to https://www.consul.io/docs/guides/outage.html
+# https://github.com/ansible/ansible/issues/10375
+# outage in depth https://sitano.github.io/2015/10/06/abt-consul-outage/
+
+
+  - name: stop consul 
+    shell: systemctl stop consul
+    become: yes
+    remote_user: "{{ ansible_ssh_user }}"
+    delegate_to: "{{ item }}"
+    with_items: "{{ groups['role=control'] | intersect(groups['running']) }}"
+    when: ( do_restart_consul == 'yes' ) or ( do_sleep_controllers == 'yes' )
+
+  - name: template raft/peers.json to replace null from graceful shutdown 
+    template: 
+      src: ../../roles/consul/templates/peers.json.j2
+      dest: /var/lib/consul/raft/peers.json
+    delegate_to: "{{ item }}"
+    with_items: "{{ groups['role=control'] | intersect(groups['running']) }}"
+    remote_user: "{{ ansible_ssh_user }}"
+    become: yes
+
+  - name: start consul 
+    shell: systemctl start consul
+    become: yes
+    delegate_to: "{{ item }}"
+    with_items: "{{ groups['role=control'] | intersect(groups['running']) }}"
+    remote_user: "{{ ansible_ssh_user }}"
+    when: ( do_restart_consul == 'yes' ) or ( do_sleep_controllers == 'yes' )
+
+###############################
+# Regroup running instances
+###############################
+
+- hosts: localhost
+# refresh terraform to get running instances
+  vars:
+    do_wake: 'yes'
+    do_sleep: 'yes'
+    default_sleep_control: 'never'
+    override_tags: 'no'
+  tasks:
+
+  # - name: refresh terraform after stopping
+  #   local_action: shell chdir=../../ pwd && terraform refresh -target=module.route53 -target=module.control-nodes -target=module.worker-nodes -target=module.edge-nodes
+  #   when: dynamic_inventory == 'terraform'
+
+  - set_fact:
+      consul_nodes: "{{ ( (groups['role=worker'] | default([])) + (groups['role=control'] | default([])) + (groups['role=edge']) | default([])) }}"
+
+  - name: get ec2_remote_facts in startup block
+    ec2_remote_facts:
+      filters:
+        vpc-id: "{{vpc_id}}"
+      region: "{{ region }}"
+      ec2_access_key: "{{ lookup('env','AWS_ACCESS_KEY') }}"
+      ec2_secret_key: "{{ lookup('env','AWS_SECRET_KEY') }}"
+    register: register_ec2_remote_facts
+
+  - name: group instances by instance state in startup block
+    group_by: 
+      key: "{{ item['state'] }}"
+    with_items: "{{ register_ec2_remote_facts['instances'] }}" 
+
+  # - name: create group of running instances after stopping
+  #   local_action:
+  #     module: group_by
+  #     key: "{{ hostvars[item]['instance_state'] }}"
+  #   with_items: "{{ consul_nodes }}"
+
+###############################
+# Disable maintenance mode on consul running instances
+###############################
+
+- hosts: running
+  serial: 1
+  vars:
+    do_wake: 'yes'
+    do_sleep: 'yes'
+    default_sleep_control: 'never'
+  pre_tasks:
+
+  - set_fact:
+      consul_nodes: "{{ ( (groups['role=worker'] | default([])) + (groups['role=control'] | default([])) + (groups['role=edge']) | default([])) }}"
+    run_once: yes
+
+  - name: wait for consul to listen
+    wait_for:
+      port: 8500
+    when: ( do_wake == 'yes' ) and ( inventory_hostname in "{{consul_nodes | list}}" )
+
+  - name: set consul maintenance disable
+    command: consul maint -disable
+    when: do_wake == 'yes' and ( inventory_hostname in "{{consul_nodes | list}}" )
+
+  - name: pause for rolling reboot
+    pause:
+      seconds: 3
+
+
+#################################
+# restart non-persistent services
+#################################
+
+  - name: reload nginx-mantlui
+    sudo: yes
+    command: systemctl restart nginx-mantlui
+    tags:
+      - mantlui
+    when: ( do_wake == 'yes' ) and ( inventory_hostname in groups['role=control'] )
+
+  - debug: 
+       msg: "Known issues: system services may not start 
+             cloud-init -> fix -> systemctl start cloud-init
+             fail2ban -> mkdir /var/run/fail2ban, systemctl start fail2ban"
+
+  - debug: msg="Now run ansible-playbook -e @security.yml mantl.yml --tags mantlui"  
+    run_once: yes
+# TODO Broken until this is resolved https://github.com/CiscoCloud/mantl/issues/1343#issuecomment-209117859
+  # roles:
+  #   - mantlui
+

--- a/plugins/inventory/terraform.py
+++ b/plugins/inventory/terraform.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""\
+"""
 Dynamic inventory for Terraform - finds all `.tfstate` files below the working
 directory and generates an inventory based on them.
 """
@@ -399,6 +399,7 @@ def aws_host(resource, module_name):
         # generic
         'public_ipv4': raw_attrs['public_ip'],
         'private_ipv4': raw_attrs['private_ip'],
+        'instance_state': raw_attrs['instance_state'],
         'provider': 'aws',
     }
 

--- a/plugins/inventory/terraform_hosts
+++ b/plugins/inventory/terraform_hosts
@@ -1,0 +1,4 @@
+[control]
+
+[master:children]
+control

--- a/roles/consul/templates/peers.json.j2
+++ b/roles/consul/templates/peers.json.j2
@@ -1,0 +1,5 @@
+[
+{% for host in groups[consul_servers_group] | intersect(groups[consul_dc_group] | default(groups['all'])) %}"{{ hostvars[host].private_ipv4 }}:8300"{% if not loop.last %}, 
+{% endif %}{% endfor %}
+
+]


### PR DESCRIPTION
This playbook is intended to reduce costs and save energy by allowing mantl clusters to be put to sleep indefinitely or on a cron cycle.
It's useful for devs working on mantl who don't want to destroy a WIP cluster but won't be touching it while they sleep or over the weekend.
A stack with a few m4.xlarge's could cost 2k per month, so one could be saving upwards of $700 per month.  Although you still pay for eips, block storage etc, typically the running instance cost is 90% of the bill.
It also tests resilience of the cluster regularly and forces users to run stateless containers backed by proper distributed stores like cassandra or mongo.

This requires elastic ips, so it is dependent on #1283  "replace public ips with elastic ips so they remain fixed on reboots"