### PR TITLE
consul: turn off proxy buffering in nginx conf

### DIFF
--- a/roles/consul/templates/consul.nginx.j2
+++ b/roles/consul/templates/consul.nginx.j2
@@ -1,53 +1,55 @@
 worker_processes	1;
 
 events {
-	worker_connections	1024;
+  worker_connections	1024;
 }
 
 http {
-	include		mime.types;
-	default_type	application/octet-stream;
+  include		mime.types;
+  default_type	application/octet-stream;
 
-	sendfile		on;
-	keepalive_timeout	65;
+  sendfile		on;
+  keepalive_timeout	65;
 
-	server {
-		listen {% raw %}{{ env "NGINX_PUBLIC_IP" }}{% endraw %}:8500 {% if do_consul_ssl|bool %}ssl{% endif %};
+  server {
+    listen {% raw %}{{ env "NGINX_PUBLIC_IP" }}{% endraw %}:8500 {% if do_consul_ssl|bool %}ssl{% endif %};
 
 {% if do_consul_ssl|bool %}
-		ssl_certificate		/etc/nginx/ssl/nginx.cert;
-		ssl_certificate_key	/etc/nginx/ssl/nginx.key;
+    ssl_certificate		/etc/nginx/ssl/nginx.cert;
+    ssl_certificate_key	/etc/nginx/ssl/nginx.key;
 
-		ssl on;
-		ssl_session_cache	builtin:1000 shared:SSL:10m;
-		ssl_protocols		TLSv1 TLSv1.1 TLSv1.2;
-		ssl_ciphers		HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
-		ssl_prefer_server_ciphers	on;
+    ssl on;
+    ssl_session_cache	builtin:1000 shared:SSL:10m;
+    ssl_protocols		TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers		HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
+    ssl_prefer_server_ciphers	on;
 
-		error_page 497 https://$host:$server_port$request_uri;
+    error_page 497 https://$host:$server_port$request_uri;
 
 {% endif %}
-		location /ui/ {
-			proxy_connect_timeout	600;
-			proxy_send_timeout	600;
-			proxy_read_timeout	600;
-			send_timeout		600;
+    location /ui/ {
+      proxy_connect_timeout	600;
+      proxy_send_timeout	600;
+      proxy_read_timeout	600;
+      send_timeout		600;
 
 {% if do_consul_auth|bool %}
-			auth_basic on;
-			auth_basic_user_file /etc/nginx/nginx-auth.conf;
+      auth_basic on;
+      auth_basic_user_file /etc/nginx/nginx-auth.conf;
 
 {% endif %}
-			proxy_pass http://localhost:8500/ui/;
-		}
+      proxy_buffering off;
+      proxy_pass http://localhost:8500/ui/;
+    }
 
-		location / {
-			proxy_connect_timeout	600;
-			proxy_send_timeout	600;
-			proxy_read_timeout	600;
-			send_timeout		600;
+    location / {
+      proxy_connect_timeout	600;
+      proxy_send_timeout	600;
+      proxy_read_timeout	600;
+      send_timeout		600;
 
-			proxy_pass http://localhost:8500/;
-		}
-	}
+      proxy_buffering off;
+      proxy_pass http://localhost:8500/;
+    }
+  }
 }


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

When there are many nodes and services registered, the Consul UI can break when accessed through the nginx-consul proxy. This can occur when the internal nodes endpoint (`/v1/internal/ui/nodes`) returns more than 16K of data. The response is truncated and the UI fails (with an unintuitive `HTTP error code from Consul: 200 OK` "error"). This turns off `proxy_buffering` in the nginx config which resolves the problem.