### PR TITLE
logstash: install on all nodes when installing elk

### DIFF
--- a/addons/elk.yml
+++ b/addons/elk.yml
@@ -6,7 +6,10 @@
 # in your cluster!
 - include: "{{ playbook_dir }}/../playbooks/check-requirements.yml"
 
-- hosts: role=control
+- hosts: all
   roles:
     - logstash
+
+- hosts: role=control
+  roles:
     - elk

--- a/roles/logstash/handlers/main.yml
+++ b/roles/logstash/handlers/main.yml
@@ -30,6 +30,13 @@
   tags:
     - logstash
 
+- name: reload consul
+  sudo: yes
+  command: systemctl is-active consul && systemctl reload consul
+  failed_when: false
+  tags:
+    - logstash
+
 - name: reload consul-template
   sudo: yes
   command: systemctl reload consul-template


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

As of https://github.com/CiscoCloud/mantl/pull/1180, logstash would only be installed on control nodes when the ELK addon is deployed. This PR updates the addon so that logstash is installed on all nodes.