### PR TITLE
Feature/traefik marathon enable

### DIFF
--- a/roles/traefik/README.rst
+++ b/roles/traefik/README.rst
@@ -40,3 +40,12 @@ You can use these variables to customize your Traefik installation.
    <https://github.com/emilevauge/traefik/blob/master/docs/index.md#marathon>`_)
 
    default: ``marathon.localhost``
+
+.. data:: traefik_marathon_expose_by_default
+
+   Automatically expose Marathon applications in traefik.
+
+   The traefik default is ``false``, or not forward traffic.
+  
+   The mantl default is set to ``true``.
+ 

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -2,3 +2,6 @@
 traefik_package: traefik-0.0.0
 traefik_marathon_endpoint: http://marathon.service.{{ consul_dns_domain }}:18080
 traefik_marathon_domain: marathon.localhost
+
+# Do Marathon apps automatically get exposed (traefik default is false)
+traefik_marathon_expose_by_default: true

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -4,4 +4,4 @@ traefik_marathon_endpoint: http://marathon.service.{{ consul_dns_domain }}:18080
 traefik_marathon_domain: marathon.localhost
 
 # Do Marathon apps automatically get exposed (traefik default is false)
-traefik_marathon_expose_by_default: true
+traefik_marathon_expose_by_default: "true"

--- a/roles/traefik/templates/traefik.toml.j2
+++ b/roles/traefik/templates/traefik.toml.j2
@@ -12,3 +12,4 @@ endpoint = "{{ traefik_marathon_endpoint }}"
 domain = "{{ traefik_marathon_domain }}"
 watch = true
 networkInterface = "{{ ansible_default_ipv4['interface'] }}"
+ExposedByDefault = "{{ traefik_marathon_expose_by_default }}"

--- a/roles/traefik/templates/traefik.toml.j2
+++ b/roles/traefik/templates/traefik.toml.j2
@@ -12,4 +12,4 @@ endpoint = "{{ traefik_marathon_endpoint }}"
 domain = "{{ traefik_marathon_domain }}"
 watch = true
 networkInterface = "{{ ansible_default_ipv4['interface'] }}"
-ExposedByDefault = "{{ traefik_marathon_expose_by_default }}"
+ExposedByDefault = {{ traefik_marathon_expose_by_default }}


### PR DESCRIPTION
Updates traefik to support the new marathon `ExposedByDefault` setting.  

- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes