### PR TITLE
Bring packer up to date with changes since 1.0

### DIFF
--- a/packer/scripts/ansible.sh
+++ b/packer/scripts/ansible.sh
@@ -3,7 +3,7 @@
 update-ca-trust
 
 # Install EPEL repository
-rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm
 
 # Install Ansible
 yum -y install ansible

--- a/packer/vagrant.json
+++ b/packer/vagrant.json
@@ -3,7 +3,8 @@
         "atlas_username": "{{env `ATLAS_USERNAME`}}",
         "atlas_name": "{{env `ATLAS_NAME`}}",
         "root": "{{template_dir}}/..",
-        "scripts": "{{template_dir}}/scripts"
+        "scripts": "{{template_dir}}/scripts",
+        "staging": "/tmp/packer-provisioner-ansible-local"
     },
     "provisioners": [
         {
@@ -25,32 +26,40 @@
             "playbook_file": "{{user `root`}}/playbooks/rolling-upgrade-packages.yml"
         },
         {
+            "type": "shell",
+            "inline": [
+                "mkdir -p {{user `staging`}}"
+            ]
+        },
+        {
+            "type": "file",
+            "source": "{{user `root`}}/group_vars",
+            "destination": "{{user `staging`}}"
+        },
+        {
+            "type": "file",
+            "source": "{{user `root`}}/library",
+            "destination": "{{user `staging`}}"
+        },
+        {
+            "type": "file",
+            "source": "{{user `root`}}/playbooks",
+            "destination": "{{user `staging`}}"
+        },
+        {
+            "type": "file",
+            "source": "{{user `root`}}/plugins",
+            "destination": "{{user `staging`}}"
+        },
+        {
+            "type": "file",
+            "source": "{{user `root`}}/roles",
+            "destination": "{{user `staging`}}/playbooks"
+        },
+        {
             "type": "ansible-local",
             "playbook_file": "{{user `root`}}/sample.yml",
-            "role_paths": [
-                "{{user `root`}}/roles/calico",
-                "{{user `root`}}/roles/chronos",
-                "{{user `root`}}/roles/collectd",
-                "{{user `root`}}/roles/common",
-                "{{user `root`}}/roles/consul",
-                "{{user `root`}}/roles/consul-template",
-                "{{user `root`}}/roles/dnsmasq",
-                "{{user `root`}}/roles/docker",
-                "{{user `root`}}/roles/etcd",
-                "{{user `root`}}/roles/glusterfs",
-                "{{user `root`}}/roles/handlers",
-                "{{user `root`}}/roles/haproxy",
-                "{{user `root`}}/roles/logrotate",
-                "{{user `root`}}/roles/logstash",
-                "{{user `root`}}/roles/lvm",
-                "{{user `root`}}/roles/mantlui",
-                "{{user `root`}}/roles/marathon",
-                "{{user `root`}}/roles/mesos",
-                "{{user `root`}}/roles/nginx",
-                "{{user `root`}}/roles/traefik",
-                "{{user `root`}}/roles/vault",
-                "{{user `root`}}/roles/zookeeper"
-            ],
+            "staging_directory": "{{user `staging`}}",
             "extra_arguments": [ "--tags", "bootstrap", "--extra-vars=\"provider=vagrant\"" ],
             "inventory_groups": "role=control,role=worker"
         },
@@ -108,7 +117,14 @@
                     "created_at": "{{timestamp}}",
                     "provider": "virtualbox"
                 }
+            },
+            {
+                "type": "shell-local",
+                "inline": [
+                    "mv builds/VirtualBox-mantl.box builds/mantl-bootstrap-$(git describe --tags --always --dirty).box"
+                ]
             }
+
         ]
     ],
     "push": {

--- a/packer/vagrant.json
+++ b/packer/vagrant.json
@@ -1,53 +1,55 @@
 {
     "variables": {
         "atlas_username": "{{env `ATLAS_USERNAME`}}",
-        "atlas_name": "{{env `ATLAS_NAME`}}"
+        "atlas_name": "{{env `ATLAS_NAME`}}",
+        "root": "{{template_dir}}/..",
+        "scripts": "{{template_dir}}/scripts"
     },
     "provisioners": [
         {
             "type": "shell",
             "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
             "scripts": [
-                "{{pwd}}/packer/scripts/ansible.sh",
-                "{{pwd}}/packer/scripts/vagrant.sh"
+                "{{user `scripts`}}/ansible.sh",
+                "{{user `scripts`}}/vagrant.sh"
             ]
         },
         {
             "type": "shell",
             "only": ["virtualbox-iso"],
             "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
-            "script": "{{pwd}}/packer/scripts/vbox.sh"
+            "script": "{{user `scripts`}}/vbox.sh"
         },
-	{
-	    "type": "ansible-local",
-	    "playbook_file": "{{pwd}}/playbooks/rolling-upgrade-packages.yml"
-	},
         {
             "type": "ansible-local",
-            "playbook_file": "{{pwd}}/sample.yml",
+            "playbook_file": "{{user `root`}}/playbooks/rolling-upgrade-packages.yml"
+        },
+        {
+            "type": "ansible-local",
+            "playbook_file": "{{user `root`}}/sample.yml",
             "role_paths": [
-                "{{pwd}}/roles/calico",
-                "{{pwd}}/roles/chronos",
-                "{{pwd}}/roles/collectd",
-                "{{pwd}}/roles/common",
-                "{{pwd}}/roles/consul",
-                "{{pwd}}/roles/consul-template",
-                "{{pwd}}/roles/dnsmasq",
-                "{{pwd}}/roles/docker",
-                "{{pwd}}/roles/etcd",
-                "{{pwd}}/roles/glusterfs",
-                "{{pwd}}/roles/handlers",
-                "{{pwd}}/roles/haproxy",
-                "{{pwd}}/roles/logrotate",
-                "{{pwd}}/roles/logstash",
-                "{{pwd}}/roles/lvm",
-                "{{pwd}}/roles/mantlui",
-                "{{pwd}}/roles/marathon",
-                "{{pwd}}/roles/mesos",
-                "{{pwd}}/roles/nginx",
-                "{{pwd}}/roles/traefik",
-                "{{pwd}}/roles/vault",
-                "{{pwd}}/roles/zookeeper"
+                "{{user `root`}}/roles/calico",
+                "{{user `root`}}/roles/chronos",
+                "{{user `root`}}/roles/collectd",
+                "{{user `root`}}/roles/common",
+                "{{user `root`}}/roles/consul",
+                "{{user `root`}}/roles/consul-template",
+                "{{user `root`}}/roles/dnsmasq",
+                "{{user `root`}}/roles/docker",
+                "{{user `root`}}/roles/etcd",
+                "{{user `root`}}/roles/glusterfs",
+                "{{user `root`}}/roles/handlers",
+                "{{user `root`}}/roles/haproxy",
+                "{{user `root`}}/roles/logrotate",
+                "{{user `root`}}/roles/logstash",
+                "{{user `root`}}/roles/lvm",
+                "{{user `root`}}/roles/mantlui",
+                "{{user `root`}}/roles/marathon",
+                "{{user `root`}}/roles/mesos",
+                "{{user `root`}}/roles/nginx",
+                "{{user `root`}}/roles/traefik",
+                "{{user `root`}}/roles/vault",
+                "{{user `root`}}/roles/zookeeper"
             ],
             "extra_arguments": [ "--tags", "bootstrap", "--extra-vars=\"provider=vagrant\"" ],
             "inventory_groups": "role=control,role=worker"
@@ -55,7 +57,7 @@
         {
             "type": "shell",
             "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
-            "script": "{{pwd}}/packer/scripts/cleanup.sh"
+            "script": "{{user `scripts`}}/cleanup.sh"
         }
     ],
     "builders": [
@@ -68,7 +70,7 @@
             "disk_size": 20480,
             "guest_os_type": "RedHat_64",
             "headless": false,
-            "http_directory": "{{pwd}}/packer/kickstarts",
+            "http_directory": "{{template_dir}}/kickstarts",
             "iso_urls": [
                 "iso/CentOS-7-x86_64-Minimal-1511.iso",
                 "http://centos.mirrors.hoobly.com/7/isos/x86_64/CentOS-7-x86_64-Minimal-1511.iso"

--- a/roles/distributive/tasks/main.yml
+++ b/roles/distributive/tasks/main.yml
@@ -68,6 +68,5 @@
     src: consul-healthcheck.json.j2
     dest: /etc/consul/distributive-{{ current_role }}-check.json
   tags:
-    - bootstrap
     - consul
     - distributive

--- a/roles/repos/tasks/main.yml
+++ b/roles/repos/tasks/main.yml
@@ -6,3 +6,5 @@
   with_items:
     - asteris-mantl-rpm.repo
     - ciscocloud-rpm.repo
+  tags:
+    bootstrap

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -exo pipefail
 
 yum makecache
 
@@ -11,8 +11,8 @@ fi
 # enable EPEL and get sshpass if it's not already installed
 if ! sshpass; then
   if ! yum list installed epel-release > /dev/null; then
-    curl -O 'http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm'
-    rpm -ivh epel-release-7-5.noarch.rpm
+    curl -f -S -s -O 'http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-6.noarch.rpm'
+    rpm -ivh epel-release-7-6.noarch.rpm
   fi
   yum install -y --enablerepo=epel sshpass
 fi


### PR DESCRIPTION
With these changes, it's possible to build a new box, switch the root Vagrantfile to use it, and vagrant up completely. It should also be easier to maintain, since it doesn't hardcode ansible roles.