### PR TITLE
Remove .node.consul from mesos hostnames

### DIFF
--- a/roles/mesos/templates/mesos-agent.sysconfig.j2
+++ b/roles/mesos/templates/mesos-agent.sysconfig.j2
@@ -2,7 +2,7 @@
 MESOS_PORT={{ mesos_follower_port }}
 MESOS_ADVERTISE_IP={{ private_ipv4 }}
 MESOS_IP={{ private_ipv4 }}
-MESOS_HOSTNAME={{ mesos_hostname | default(inventory_hostname + ".node." + consul_dns_domain) }}
+MESOS_HOSTNAME={{ mesos_hostname | default(inventory_hostname) }}
 MESOS_EXTERNAL_LOG_FILE=/var/log/mesos/mesos-agent.log
 MESOS_LOGGING_LEVEL={{ mesos_logging_level }}
 

--- a/roles/mesos/templates/mesos-master.sysconfig.j2
+++ b/roles/mesos/templates/mesos-master.sysconfig.j2
@@ -2,7 +2,7 @@
 MESOS_PORT={{ mesos_leader_port }}
 MESOS_ADVERTISE_IP={{ private_ipv4 }}
 MESOS_IP={{ private_ipv4 }}
-MESOS_HOSTNAME={{ mesos_hostname | default(inventory_hostname + ".node." + consul_dns_domain) }}
+MESOS_HOSTNAME={{ mesos_hostname | default(inventory_hostname) }}
 MESOS_EXTERNAL_LOG_FILE=/var/log/mesos/mesos-master.log
 MESOS_LOGGING_LEVEL={{ mesos_logging_level }}
 


### PR DESCRIPTION
This removes .node.consul from mesos registration, and only uses the ansible `inventory_hostname`. 

This is to fix external links (as in marathon)
from breaking on hosts that aren't in the .consul
domain.

- [ ] Installs cleanly on a fresh build of most recent master branch
- [ ] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes
