### PR TITLE
force remove containers in systemd services

### DIFF
--- a/roles/haproxy/templates/haproxy.service.j2
+++ b/roles/haproxy/templates/haproxy.service.j2
@@ -10,7 +10,7 @@ Restart=on-failure
 RestartSec=20
 TimeoutStartSec=0
 
-ExecStartPre=-/usr/bin/docker rm haproxy
+ExecStartPre=-/usr/bin/docker rm -f haproxy
 ExecStartPre=-/usr/bin/docker pull {{ haproxy_image }}:{{ haproxy_image_tag }} 
 
 ExecStart=/usr/bin/docker run \

--- a/roles/logstash/templates/logstash-service.j2
+++ b/roles/logstash/templates/logstash-service.j2
@@ -9,7 +9,7 @@ Restart=always
 RestartSec=20
 TimeoutStartSec=20m
 
-ExecStartPre=-/usr/bin/docker rm logstash
+ExecStartPre=-/usr/bin/docker rm -f logstash
 ExecStartPre=-/usr/bin/docker pull {{ logstash_image }}:{{ logstash_image_tag }}
 
 ExecStart=/usr/bin/docker run \
@@ -41,7 +41,7 @@ ExecStart=/usr/bin/docker run \
 
 ExecStop=/bin/bash -c " \
     /usr/bin/docker kill logstash && \
-    /usr/bin/docker rm logstash"
+    /usr/bin/docker rm -f logstash"
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/mantlui/templates/nginx-mantlui.service.j2
+++ b/roles/mantlui/templates/nginx-mantlui.service.j2
@@ -10,7 +10,7 @@ Restart=on-failure
 RestartSec=20
 TimeoutStartSec=0
 
-ExecStartPre=-/usr/bin/docker rm nginx-mantlui
+ExecStartPre=-/usr/bin/docker rm -f nginx-mantlui
 ExecStartPre=-/usr/bin/docker pull {{ mantlui_nginx_image }}:{{ mantlui_nginx_image_tag }}
 
 ExecStart=/usr/bin/docker run \

--- a/roles/nginx/templates/nginx-consul.service.j2
+++ b/roles/nginx/templates/nginx-consul.service.j2
@@ -10,7 +10,7 @@ Restart=on-failure
 RestartSec=20
 TimeoutStartSec=0
 
-ExecStartPre=-/usr/bin/docker rm nginx-consul
+ExecStartPre=-/usr/bin/docker rm -f nginx-consul
 ExecStartPre=-/usr/bin/docker pull {{ consul_nginx_image }}:{{ consul_nginx_image_tag }} 
 
 ExecStart=/usr/bin/docker run \


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

fixes #1390

---

this works around the problem in https://github.com/CiscoCloud/mantl/pull/1239#issuecomment-215257670

When the error occurs, the `/var/lib/docker/containers/<containerid>` directory may get left behind but the container is removed and the service can be restarted.
