### PR TITLE
Make Travis build on pushes to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - docker pull $DOCKER_IMAGE
   - docker run $DOCKER_ARGS -v $(pwd)/testing:/local -v $(pwd):/mantl $DOCKER_SECRETS $DOCKER_IMAGE "python2 docker.py ci-setup"
 
-script: 
+script:
   - python2 testing/test-health-checks.py
   - docker run $DOCKER_ARGS -v $(pwd)/testing:/local -v $(pwd):/mantl $DOCKER_SECRETS $DOCKER_IMAGE "python docker.py ci-build"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+
 env:
   global:
   - TF_VAR_build_number=${TRAVIS_JOB_NUMBER/./-}
@@ -8,6 +9,10 @@ env:
   - TERRAFORM_FILE=testing/aws.tf DOCKER_SECRETS='-e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID'
   - TERRAFORM_FILE=testing/do.tf DOCKER_SECRETS='-e DIGITALOCEAN_TOKEN'
   - TERRAFORM_FILE=testing/gce.tf DOCKER_SECRETS='-e GOOGLE_CREDENTIALS'
+
+branches:
+  only:
+    - master
 
 before_script:
   - export CI_HEAD_COMMIT=$(git rev-list -n 1 --no-merges --branches="$(git rev-parse --abbrev-ref HEAD)" master...HEAD)

--- a/docker.py
+++ b/docker.py
@@ -154,7 +154,7 @@ def ci_build():
     # Filter out commits that are pushes to non-master branches
     ci_branch = os.environ['TRAVIS_BRANCH']
     ci_is_pr = os.environ['TRAVIS_PULL_REQUEST']
-    if ci_branch is not 'master' and ci_is_pr is False:
+    if ci_branch != 'master' and ci_is_pr != "1":
         logging.info("We don't want to build on pushes to branches that aren't master.")
         exit(0)
 


### PR DESCRIPTION

We disabled push builds for Travis because it was crowding up the build queue. With this, we should be able to turn them back on.