### PR TITLE
Remove duplicate "reload consul" handlers in core roles

### DIFF
--- a/roles/kubernetes-master/handlers/main.yml
+++ b/roles/kubernetes-master/handlers/main.yml
@@ -8,7 +8,3 @@
   service:
     name: kubelet
     state: restarted
-
-- name: reload consul
-  sudo: yes
-  command: systemctl reload consul

--- a/roles/kubernetes-master/meta/main.yml
+++ b/roles/kubernetes-master/meta/main.yml
@@ -1,4 +1,3 @@
 ---
 dependencies:
-  - role: repos
   - role: handlers

--- a/roles/kubernetes-node/handlers/main.yml
+++ b/roles/kubernetes-node/handlers/main.yml
@@ -8,7 +8,3 @@
   service:
     name: kubelet
     state: restarted
-
-- name: reload consul
-  sudo: yes
-  command: systemctl reload consul

--- a/roles/kubernetes-node/meta/main.yml
+++ b/roles/kubernetes-node/meta/main.yml
@@ -1,4 +1,3 @@
 ---
 dependencies:
-  - role: repos
   - role: handlers

--- a/roles/marathon/handlers/main.yml
+++ b/roles/marathon/handlers/main.yml
@@ -14,10 +14,6 @@
 - name: wait for marathon to listen
   command: /usr/bin/smlr http "http://localhost:{{ marathon_port }}/ping"
 
-- name: reload consul
-  sudo: yes
-  command: "{{ consul_bin }} reload"
-
 - name: restart nginx-marathon
   sudo: yes
   command: systemctl restart nginx-marathon

--- a/roles/traefik/handlers/main.yml
+++ b/roles/traefik/handlers/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: reload consul
-  sudo: yes
-  command: systemctl reload consul
-
 - name: reload systemd
   sudo: yes
   command: systemctl daemon-reload

--- a/roles/traefik/meta/main.yml
+++ b/roles/traefik/meta/main.yml
@@ -1,4 +1,3 @@
 ---
 dependencies:
-  - role: repos
   - role: handlers


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

Instead, these roles will depend on the "handlers" role. Waiting on #1224 to remove the duplication in the addon roles.

Fixes #1343.

We should also think about removing duplicates of other handlers, like "reload systemd".

This is currently untested, since Vagrant isn't working and AWS is over quota. To test, just install chronos on a fresh mantl cluster. 