### PR TITLE
add playbook for upgrading a 1.0.3 cluster to 1.1

### DIFF
--- a/docs/upgrading/index.rst
+++ b/docs/upgrading/index.rst
@@ -21,6 +21,49 @@ second upgrades each node serially. You want the use the rolling upgrade on a
 cluster that is already running consul; otherwise, you will likely lose quorum
 and destabilize your cluster.
 
+Upgrading from 1.0.3 to 1.1
+---------------------------
+
+If you have a running 1.0.3 cluster, you need to perform the following steps:
+
+Update security.yml
+~~~~~~~~~~~~~~~~~~~
+
+Mantl 1.0 requires some additional settings in the ``security.yml`` file that
+you generated when you built your cluster. To auto-generate the necessary
+settings, you simply need to re-run ``security-setup``:
+
+.. code-block:: shell
+
+  ./security-setup
+
+Of course, if you customized your security settings (manually or using the CLI
+arguments), you should be careful to re-run ``security-setup`` the same way.
+
+The main change was a switch to using a single certificate for internal nginx
+proxies.
+
+Core Component Rolling Upgrade
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: shell
+
+  ansible-playbook -e @security.yml playbooks/upgrade-1.0.3.yml
+
+This playbook performs a rolling update of several core components including
+consul, nginx-consul based services, and mantl-dns. Due to compatibility issues,
+we also disable the collectd Docker plugin.
+
+Upgrade to Mantl 1.1
+~~~~~~~~~~~~~~~~~~~~
+
+At this point, you can now upgrade the rest of the components to 1.1 with the
+standard provisioning playbook:
+
+.. code-block:: shell
+
+  ansible-playbook -e @security.yml mantl.yml
+
 Upgrading from 0.5.1 to 1.0
 ---------------------------
 

--- a/playbooks/upgrade-1.0.3.yml
+++ b/playbooks/upgrade-1.0.3.yml
@@ -1,0 +1,89 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: check that the host certificate exists
+      local_action: stat path=../ssl/certs/host.cert.pem
+      register: host_cert
+
+    - name: security-setup required
+      when: not host_cert.stat.exists
+      fail:
+        msg: |
+          You must re-run the security-setup script when upgrading from 1.0.3.
+          See
+          http://docs.mantl.io/en/latest/getting_started/index.html#step-2-run-security-setup
+          for more information.
+
+- include: ./upgrade-nginx-consul.yml
+- include: ./upgrade-consul.yml consul_create_secure_acl=false
+
+- hosts: all
+  serial: "{{ serial | default(1) }}"
+
+  roles:
+    - repos
+
+  tasks:
+
+    - include_vars: ../roles/dnsmasq/defaults/main.yml
+
+    - name: deploy root ca
+      sudo: yes
+      copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        owner: root
+      with_items:
+        - src: ../ssl/cacert.pem
+          dest: /etc/pki/CA/ca.cert
+        - src: ../ssl/cacert.pem
+          dest: /etc/pki/ca-trust/source/anchors/cacert.pem
+        - src: ../ssl/private/cakey.pem
+          dest: /etc/pki/CA/ca.key
+        - src: ../ssl/certs/host.cert.pem
+          dest: /etc/pki/tls/certs/host.cert
+        - src: ../ssl/private/host.key.pem
+          dest: /etc/pki/tls/private/host.key
+
+    - name: update-ca-trust
+      sudo: yes
+      command: update-ca-trust
+
+    - name: remove docker collectd plugin
+      become: yes
+      file:
+        path: /etc/collectd.d/docker.conf
+        state: absent
+
+    - name: install mantl-dns
+      sudo: yes
+      yum:
+        name: "mantl-dns-{{ mantl_dns_version }}"
+        state: installed
+
+    - name: update /etc/dnsmasq.d/10-consul if needed
+      sudo: yes
+      shell: stat /etc/dnsmasq.d/10-consul.rpmnew && mv /etc/dnsmasq.d/10-consul.rpmnew /etc/dnsmasq.d/10-consul
+      failed_when: false
+
+    - name: restart services
+      become: yes
+      service:
+        name: "{{ item }}"
+        state: restarted
+      with_items:
+        - nginx-consul
+        - collectd
+
+- hosts: role=control
+  serial: "{{ serial | default(1) }}"
+  tasks:
+
+    - name: restart services
+      become: yes
+      service:
+        name: "{{ item }}"
+        state: restarted
+      with_items:
+        - nginx-mantlui

--- a/playbooks/upgrade-consul.yml
+++ b/playbooks/upgrade-consul.yml
@@ -1,6 +1,8 @@
 ---
 - hosts: all
   serial: "{{ serial | default(1) }}"
+  vars:
+    consul_create_secure_acl: true
   tasks:
     - include_vars: ../roles/consul/defaults/main.yml
 
@@ -26,5 +28,6 @@
       sudo: yes
       run_once: yes
       command: consul-cli acl-update --token={{ consul_acl_master_token }} --name="Mantl Secure Token" --rule='key:secure:write' --rule='service::write' {{ consul_acl_secure_token }}
+      when: consul_create_secure_acl
       tags:
         - consul


### PR DESCRIPTION


- [x] Installs cleanly on a fresh build of most recent master branch n/a
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

Fixes #1392 
Fixes #1292 

Ready for review but extensive testing should wait until other 1.1 pull requests are merged.

