### PR TITLE
aws: gp2 volume type for root device

### DIFF
--- a/terraform/aws/instance/main.tf
+++ b/terraform/aws/instance/main.tf
@@ -3,7 +3,9 @@ variable "count_format" {default = "%02d"}
 variable "iam_profile" {default = "" }
 variable "ec2_type" {default = "m3.medium"}
 variable "ebs_volume_size" {default = "20"} # size is in gigabytes
+variable "ebs_volume_type" {default = "gp2"}
 variable "data_ebs_volume_size" {default = "20"} # size is in gigabytes
+variable "data_ebs_volume_type" {default = "gp2"}
 variable "role" {}
 variable "short_name" {default = "mantl"}
 variable "availability_zones" {}
@@ -19,7 +21,7 @@ resource "aws_ebs_volume" "ebs" {
   availability_zone = "${element(split(",", var.availability_zones), count.index)}"
   count = "${var.count}"
   size = "${var.data_ebs_volume_size}"
-  type = "gp2"
+  type = "${var.data_ebs_volume_type}"
 
   tags {
     Name = "${var.short_name}-${var.role}-lvm-${format(var.count_format, count.index+1)}"
@@ -39,6 +41,7 @@ resource "aws_instance" "instance" {
   root_block_device {
     delete_on_termination = true
     volume_size = "${var.ebs_volume_size}"
+    volume_type = "${var.ebs_volume_type}"
   }
 
 


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes n/a

---

* updated the aws terraform instance root volumes to use the gp2 type by
  default
* configurable for root and attached volumes
* however, without manual configuration, the options are effectively limited to `standard` and `gp2` due to terraform limitations. The `io1` requires specifying `iops` on each volume but that setting is not compatible with the other types and cannot currently be conditionally included. If you want to set `io1`, you will also need to update `terraform/aws/instance/main.tf` to specify the `iops` attribute on the specific volume(s).
* I did not update the legacy `terraform/aws/aws.tf` terraform with this option.