### PR TITLE
TRAVIS rm install step, containers have deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - TERRAFORM_FILE=testing/aws.tf DOCKER_SECRETS='-e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID'
   - TERRAFORM_FILE=testing/do.tf DOCKER_SECRETS='-e DIGITALOCEAN_TOKEN'
   - TERRAFORM_FILE=testing/gce.tf DOCKER_SECRETS='-e GOOGLE_CREDENTIALS'
-install: pip install -r requirements.txt
+
 before_script:
   - export CI_HEAD_COMMIT=$(git rev-list -n 1 --no-merges --branches="$(git rev-parse --abbrev-ref HEAD)" master...HEAD)
   - echo $CI_HEAD_COMMIT


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

Because we migrated to using a container based system, we no longer need
to install dependencies on the travis machine itself. So, I've removed
that line, and should speed up test runs