### PR TITLE
Add dependency on handlers role to docker role

### DIFF
--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: lvm
+  - role: handlers


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

Useful if you run the Docker role by itself. Fixes this issue:
```
TASK: [docker | systemd drop-in for options] ********************************** 
ok: [lb0-worker-003] => (item=10-options.conf)
ok: [lb0-worker-001] => (item=10-options.conf)
ok: [lb0-kubeworker-002] => (item=10-options.conf)
ok: [lb0-worker-004] => (item=10-options.conf)
ok: [lb0-worker-002] => (item=10-options.conf)
ok: [lb0-kubeworker-001] => (item=10-options.conf)
ok: [lb0-edge-01] => (item=10-options.conf)
ok: [lb0-control-03] => (item=10-options.conf)
ok: [lb0-control-02] => (item=10-options.conf)
ok: [lb0-control-01] => (item=10-options.conf)
changed: [lb0-worker-003] => (item=12-network-options.conf)
changed: [lb0-worker-004] => (item=12-network-options.conf)
changed: [lb0-worker-001] => (item=12-network-options.conf)
changed: [lb0-worker-002] => (item=12-network-options.conf)
changed: [lb0-kubeworker-001] => (item=12-network-options.conf)
changed: [lb0-kubeworker-002] => (item=12-network-options.conf)
changed: [lb0-edge-01] => (item=12-network-options.conf)
changed: [lb0-control-01] => (item=12-network-options.conf)
changed: [lb0-control-03] => (item=12-network-options.conf)
changed: [lb0-control-02] => (item=12-network-options.conf)
ERROR: change handler (reload systemd) is not defined
```
