### PR TITLE
[TRAVIS] Increase timeout for health checks

### DIFF
--- a/testing/healthchecks.py
+++ b/testing/healthchecks.py
@@ -94,7 +94,7 @@ def cluster_health_check(ip_addresses):
 
 if __name__ == "__main__":
     print("Waiting for cluster to finalize init before starting health checks")
-    sleep(60*2)  # two minutes
+    sleep(60*5)  # five minutes
 
     # Get IP addresses of hosts from a dynamic inventory script
     cmd = ["python2", "plugins/inventory/terraform.py", "--list"]


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

We originally added a two minute timeout to the health checks to allow
the cluster time to become healthy. Lately, there are a couple of checks
that may need more than two minutes, so we are going to increase it to
five.