### PR TITLE
mantl-api: version 0.2.1

### DIFF
--- a/roles/marathon/defaults/main.yml
+++ b/roles/marathon/defaults/main.yml
@@ -37,4 +37,4 @@ mesos_consul_refresh: "7s"
 marathon_consul_image: ciscocloud/marathon-consul
 marathon_consul_image_tag: 0.2
 mantl_api_image: ciscocloud/mantl-api
-mantl_api_image_tag: 0.2.0
+mantl_api_image_tag: 0.2.1


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

fixes bug that occurs when using custom packages that don't have a framework attribute set