### PR TITLE
Consul TLS certs: valid for *.node and *.service

### DIFF
--- a/security-setup
+++ b/security-setup
@@ -463,10 +463,10 @@ class Component(object):
         csr = posixpath.join(CERT_PATH, 'certs', name + '.csr.pem')
         cert = posixpath.join(CERT_PATH, 'certs', name + '.cert.pem')
         with self.modify_security() as config:
-	    consul_dns_domain = config['consul_dns_domain']
+            consul_dns_domain = config['consul_dns_domain']
 
-	common = "server.%s" % consul_dns_domain
-	san = dict(SAN='DNS:localhost,DNS:*.node.' + consul_dns_domain + ',DNS:*.service.' + consul_dns_domain + ',IP:127.0.0.1')
+        common = "server.%s" % consul_dns_domain
+        san = dict(SAN='DNS:localhost,DNS:*.node,DNS:*.service,DNS:*.node.' + consul_dns_domain + ',DNS:*.service.' + consul_dns_domain + ',IP:127.0.0.1')
 
         with self.chdir(CERT_PATH):
             if posixpath.exists(key):
@@ -521,12 +521,12 @@ class Certificates(Component):
         return [self.domain, self.ca, self.host_cert]
 
     def domain(self):
-	with self.modify_security() as config:
-	    if 'consul_dns_domain' not in config:
-		config['consul_dns_domain'] = self.args.consul_dns_domain
-		print("set consul domain")
-	    else:
-		print('consul domain already set')
+        with self.modify_security() as config:
+            if 'consul_dns_domain' not in config:
+                config['consul_dns_domain'] = self.args.consul_dns_domain
+                print("set consul domain")
+            else:
+                print('consul domain already set')
 
     def ca(self):
         "certificate authority"
@@ -584,7 +584,7 @@ class Nginx(Component):
 class Consul(Component):
     def check(self):
         return [self.check_security, self.gossip_key, self.master_acl_token,
-		self.agent_acl_token, self.secure_acl_token]
+                self.agent_acl_token, self.secure_acl_token]
 
     def check_security(self):
         "check security"


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

Since services and nodes can now be addressed via DNS without using the consul_dns_domain, we should make their TLS certs valid for those names.

I also replaced all tabs with four spaces, we should always be consistent. Here's the [diff with whitespace changes ignored](https://github.com/CiscoCloud/mantl/pull/1448/files?w=1).

Fixes #1435