### PR TITLE
TRAVIS rsync & cache /var/log on build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ after_script:
   # rsync logs from the cluster to .mantl-ci-log
   - mkdir -p .mantl-ci-log/$TF_VAR_build_number
   - if [ $TRAVIS_TEST_RESULT == 1 ]; do rysnc --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; fi
-- docker run $DOCKER_ARGS -v $(pwd)/testing:/local -v $(pwd):/mantl $DOCKER_SECRETS
-  $DOCKER_IMAGE "python docker.py ci-destroy"
+  - docker run $DOCKER_ARGS -v $(pwd)/testing:/local -v $(pwd):/mantl $DOCKER_SECRETS $DOCKER_IMAGE "python docker.py ci-destroy"
 sudo: required
 services:
 - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,5 +48,5 @@ cache:
 before_cache:
   # rsync logs from the cluster to .mantl-ci-log
   - mkdir -p .mantl-ci-log/$TF_VAR_build_number
-  - dd if=/dev/zero of=.mantl-ci-log/$TF_VAR_build_number/test.txt count=1024 bs=1024
+  - dd if=/dev/urandom of=.mantl-ci-log/$TF_VAR_build_number/test.txt count=1024 bs=1024
   - if [ $TRAVIS_TEST_RESULT == 1 ]; then rsync -e "ssh -i testing/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no" --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; else echo "Skipping cache step for successful build";  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ script:
   - docker run $DOCKER_ARGS -v $(pwd)/testing:/local -v $(pwd):/mantl $DOCKER_SECRETS $DOCKER_IMAGE "python docker.py ci-build"
 
 after_script:
-  # rsync logs from the cluster to .mantl-ci-log
-  - mkdir -p .mantl-ci-log/$TF_VAR_build_number
-  - if [ $TRAVIS_TEST_RESULT == 1 ]; do rsync --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; else echo "Skipping cache step for successful build";  fi
   - docker run $DOCKER_ARGS -v $(pwd)/testing:/local -v $(pwd):/mantl $DOCKER_SECRETS $DOCKER_IMAGE "python docker.py ci-destroy"
 sudo: required
 services:
@@ -48,3 +45,7 @@ before_install:
 cache:
   directories:
     - .mantl-ci-log
+before_cache:
+  # rsync logs from the cluster to .mantl-ci-log
+  - mkdir -p .mantl-ci-log/$TF_VAR_build_number
+  - if [ $TRAVIS_TEST_RESULT == 1 ]; do rsync --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; else echo "Skipping cache step for successful build";  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ cache:
 before_cache:
   # rsync logs from the cluster to .mantl-ci-log
   - mkdir -p .mantl-ci-log/$TF_VAR_build_number
-  - if [ $TRAVIS_TEST_RESULT == 1 ]; then rsync -e "ssh -o StrictHostKeyChecking=no" --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; else echo "Skipping cache step for successful build";  fi
+  - if [ $TRAVIS_TEST_RESULT == 1 ]; then rsync -e "ssh -i testing/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no" --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; else echo "Skipping cache step for successful build";  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ cache:
 before_cache:
   # rsync logs from the cluster to .mantl-ci-log
   - mkdir -p .mantl-ci-log/$TF_VAR_build_number
-  - if [ $TRAVIS_TEST_RESULT == 1 ]; then rsync --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; else echo "Skipping cache step for successful build";  fi
+  - if [ $TRAVIS_TEST_RESULT == 1 ]; then rsync -e "ssh -o StrictHostKeyChecking=no" --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; else echo "Skipping cache step for successful build";  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ after_script:
 sudo: required
 services:
 - docker
-addons:
-  artifacts:
-    s3_region: "us-west-1"
+
 notifications:
   slack:
     secure: eX3VgtKQ48rzKGdXpIZZVYINffI2wbqhqoJFUxHO1Zku6tXzbt0R+r3NVHo37wBID63bkXjYqjZuv+JRUtvf/XO51+QkTqCCZ6iC3lr6IEqRpzxXsmNYf+QPhuN2kvVTSyycHFXdwQLL7sCniFSmEcLdu6xMpobI4PUwi2OvHj4=

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 after_script:
   # rsync logs from the cluster to .mantl-ci-log
   - mkdir -p .mantl-ci-log/$TF_VAR_build_number
-  - if [ $TRAVIS_TEST_RESULT == 1 ]; do rsync --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; fi
+  - if [ $TRAVIS_TEST_RESULT == 1 ]; do rsync --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; else echo "Skipping cache step for successful build";  fi
   - docker run $DOCKER_ARGS -v $(pwd)/testing:/local -v $(pwd):/mantl $DOCKER_SECRETS $DOCKER_IMAGE "python docker.py ci-destroy"
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 after_script:
   # rsync logs from the cluster to .mantl-ci-log
   - mkdir -p .mantl-ci-log/$TF_VAR_build_number
-  - if [ $TRAVIS_TEST_RESULT == 1 ]; do rysnc --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; fi
+  - if [ $TRAVIS_TEST_RESULT == 1 ]; do rsync --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; fi
   - docker run $DOCKER_ARGS -v $(pwd)/testing:/local -v $(pwd):/mantl $DOCKER_SECRETS $DOCKER_IMAGE "python docker.py ci-destroy"
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ cache:
 before_cache:
   # rsync logs from the cluster to .mantl-ci-log
   - mkdir -p .mantl-ci-log/$TF_VAR_build_number
-  - if [ $TRAVIS_TEST_RESULT == 1 ]; do rsync --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; else echo "Skipping cache step for successful build";  fi
+  - if [ $TRAVIS_TEST_RESULT == 1 ]; then rsync --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; else echo "Skipping cache step for successful build";  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,5 @@ cache:
 before_cache:
   # rsync logs from the cluster to .mantl-ci-log
   - mkdir -p .mantl-ci-log/$TF_VAR_build_number
+  - dd if=/dev/zero of=.mantl-ci-log/$TF_VAR_build_number/test.txt count=1024 bs=1024
   - if [ $TRAVIS_TEST_RESULT == 1 ]; then rsync -e "ssh -i testing/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no" --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; else echo "Skipping cache step for successful build";  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,8 @@ sudo: required
 services:
 - docker
 addons:
-  apt:
-    packages:
-    - unzip
+  artifacts:
+    s3_region: "us-west-1"
 notifications:
   slack:
     secure: eX3VgtKQ48rzKGdXpIZZVYINffI2wbqhqoJFUxHO1Zku6tXzbt0R+r3NVHo37wBID63bkXjYqjZuv+JRUtvf/XO51+QkTqCCZ6iC3lr6IEqRpzxXsmNYf+QPhuN2kvVTSyycHFXdwQLL7sCniFSmEcLdu6xMpobI4PUwi2OvHj4=
@@ -42,10 +41,7 @@ before_install:
   # the cli tool will append the whole command as its own item; I wrapped that line with the if statement below
   - if [ -n "$ARE_SECRETS_AVAILABLE" ]; then openssl aes-256-cbc -K $encrypted_6a9d32f3e0bd_key -iv $encrypted_6a9d32f3e0bd_iv -in ci.enc -out testing/ci; else echo "Secrets not available...skipping"; fi
 
-cache:
-  directories:
-    - .mantl-ci-log
-before_cache:
+after_failure:
   # rsync logs from the cluster to .mantl-ci-log
   - mkdir -p .mantl-ci-log/$TF_VAR_build_number
   - dd if=/dev/urandom of=.mantl-ci-log/$TF_VAR_build_number/test.txt count=1024 bs=1024

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ script:
   - docker run $DOCKER_ARGS -v $(pwd)/testing:/local -v $(pwd):/mantl $DOCKER_SECRETS $DOCKER_IMAGE "python docker.py ci-build"
 
 after_script:
+  # rsync logs from the cluster to .mantl-ci-log
+  - mkdir -p .mantl-ci-log/$TF_VAR_build_number
+  - if [ $TRAVIS_TEST_RESULT == 1 ]; do rysnc --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; fi
 - docker run $DOCKER_ARGS -v $(pwd)/testing:/local -v $(pwd):/mantl $DOCKER_SECRETS
   $DOCKER_IMAGE "python docker.py ci-destroy"
 sudo: required
@@ -42,3 +45,7 @@ before_install:
   # the documentation for encrypting files is here: https://docs.travis-ci.com/user/encrypting-files/
   # the cli tool will append the whole command as its own item; I wrapped that line with the if statement below
   - if [ -n "$ARE_SECRETS_AVAILABLE" ]; then openssl aes-256-cbc -K $encrypted_6a9d32f3e0bd_key -iv $encrypted_6a9d32f3e0bd_iv -in ci.enc -out testing/ci; else echo "Secrets not available...skipping"; fi
+
+cache:
+  directories:
+    - .mantl-ci-log

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ after_failure:
   # rsync logs from the cluster to .mantl-ci-log
   - mkdir -p .mantl-ci-log/$TF_VAR_build_number
   - dd if=/dev/urandom of=.mantl-ci-log/$TF_VAR_build_number/test.txt count=1024 bs=1024
-  - if [ $TRAVIS_TEST_RESULT == 1 ]; then rsync -e "ssh -i testing/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no" --super -a centos@$(plugins/inventory/terraform.py --hostfile | awk '/control-01/ {print $1}'):/var/log/* .mantl-ci-log/$TF_VAR_build_number; else echo "Skipping cache step for successful build";  fi
+  - docker run $DOCKER_ARGS -v $(pwd)/testing:/local -v $(pwd):/mantl $DOCKER_SECRETS $DOCKER_IMAGE "python docker.py ci-log-cache"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM alpine:3.3
 
-RUN apk add --no-cache build-base curl git openssh openssl py-pip python python-dev unzip \
+RUN apk add --no-cache build-base curl git openssh openssl openssl-dev libffi-dev py-cffi py-pip python python-dev rsync unzip \
 	&& git clone https://github.com/CiscoCloud/mantl /mantl \
-	&& apk add --no-cache build-base python-dev py-pip \
 	&& pip install -r /mantl/requirements.txt \
-	&& apk del build-base python-dev py-pip
+	&& apk del build-base libffi-dev openssl-dev py-cffi python-dev py-pip
 
 VOLUME /local
 ENV MANTL_CONFIG_DIR /local

--- a/docker.py
+++ b/docker.py
@@ -221,12 +221,14 @@ def ci_log_cache():
     ip = ""
     with open("terraform.tfstate") as tf:
         tfstate = json.load(tf)
-        resources = [module['resources'] 
-                for module in tfstate['modules'] 
-                if len(module['resources']) > 0 and "control-nodes" in module['path']]
-        for resource in resources:
-            if "control-01" in resource['primary']['attributes']['tags.Name']:
-                ip = resource['primary']['attributes']['public_ip']
+        control_node_resources = None 
+        for module in tfstate['modules']: 
+            if "control-nodes" in module['path']:
+                control_node_resources = module['resources']
+        for resource in control_node_resources.values():
+            if 'tags.Name' in resource['primary']['attributes']:
+                if "control-01" in resource['primary']['attributes']['tags.Name']:
+                    ip = resource['primary']['attributes']['public_ip']
 
     print(ip)
     src = "centos@{}:/var/log/cloud-init-output.log".format(ip)

--- a/docker.py
+++ b/docker.py
@@ -227,7 +227,7 @@ def ci_log_cache():
     src = "centos@{}:/var/log/*".format(ip)
     dest = ".mantl-ci-log/{}".format(os.environ['TF_VAR_build_number'])
     rysnc_cmd = [
-        "rsync", "--super", "-a", src, , dest, 
+        "rsync", "--super", "-a", src, dest, 
         "-e", "ssh -i /local/ci -o BatchMode=yes -o StrictHostKeyChecking=no"
         ]
 

--- a/docker.py
+++ b/docker.py
@@ -219,7 +219,7 @@ def ci_log_cache():
     
     # parse json of tfstate for ip
     ip = ""
-    with open("/local/terraform.tfstate") as tf:
+    with open(os.environ['TERRAFORM_STATE']) as tf:
         tfstate = json.load(tf)
         resources = None 
         for module in tfstate['modules']: 

--- a/docker.py
+++ b/docker.py
@@ -228,6 +228,7 @@ def ci_log_cache():
             if "control-01" in resource['primary']['attributes']['tags.Name']:
                 ip = resource['primary']['attributes']['public_ip']
 
+    print(ip)
     src = "centos@{}:/var/log/cloud-init-output.log".format(ip)
     dest = ".mantl-ci-log/{}".format(os.environ['TF_VAR_build_number'])
     rsync_cmd = [
@@ -235,6 +236,7 @@ def ci_log_cache():
         "-e", "ssh -i /root/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no"
         ]
 
+    print(rsync_cmd)
     exit(call(rsync_cmd))
 
 

--- a/docker.py
+++ b/docker.py
@@ -223,7 +223,7 @@ def ci_log_cache():
         tfstate = json.load(tf)
         resources = None 
         for module in tfstate['modules']: 
-            if module['path'].startswith('mantl-ci'):
+            if module['path'][1].startswith('mantl-ci'):
                 resources = module['resources']
         for resource in resources.values():
             if 'tags.Name' in resource['primary']['attributes']:

--- a/docker.py
+++ b/docker.py
@@ -219,7 +219,7 @@ def ci_log_cache():
     
     # parse json of tfstate for ip
     ip = ""
-    with open("terraform.tfstate") as tf:
+    with open("/local/terraform.tfstate") as tf:
         tfstate = json.load(tf)
         resources = None 
         for module in tfstate['modules']: 

--- a/docker.py
+++ b/docker.py
@@ -221,11 +221,11 @@ def ci_log_cache():
     ip = ""
     with open("terraform.tfstate") as tf:
         tfstate = json.load(tf)
-        control_node_resources = None 
+        resources = None 
         for module in tfstate['modules']: 
-            if "control-nodes" in module['path']:
-                control_node_resources = module['resources']
-        for resource in control_node_resources.values():
+            if module['path'].startswith('mantl-ci'):
+                resources = module['resources']
+        for resource in resources.values():
             if 'tags.Name' in resource['primary']['attributes']:
                 if "control-01" in resource['primary']['attributes']['tags.Name']:
                     ip = resource['primary']['attributes']['public_ip']

--- a/docker.py
+++ b/docker.py
@@ -184,7 +184,7 @@ python2 ./testing/build-cluster.py'
 def ci_destroy():
     """Cleanup after ci_build"""
 
-    destroy_cmd = "terraform destroy -force"
+    destroy_cmd = "terraform destroy -force -state=$TERRAFORM_STATE"
     if 'OS_IP' in os.environ:
         ssh_cmd = '''
 ssh -i {keypath} -p {ssh_port}

--- a/docker.py
+++ b/docker.py
@@ -224,7 +224,7 @@ def ci_log_cache():
             idx = host.index(" ")
             ip = host[:idx]
 
-    src = "centos@{}:/var/log/*".format(ip)
+    src = "centos@{}:/var/log/cloud-init-output.log".format(ip)
     dest = ".mantl-ci-log/{}".format(os.environ['TF_VAR_build_number'])
     rsync_cmd = [
         "rsync", "--super", "-a", src, dest, 

--- a/docker.py
+++ b/docker.py
@@ -184,7 +184,7 @@ python2 ./testing/build-cluster.py'
 def ci_destroy():
     """Cleanup after ci_build"""
 
-    destroy_cmd = "terraform destroy -force -state=$TERRAFORM_STATE"
+    destroy_cmd = "terraform destroy -force -state={}".format(os.environ["TERRAFORM_STATE"])
     if 'OS_IP' in os.environ:
         ssh_cmd = '''
 ssh -i {keypath} -p {ssh_port}

--- a/docker.py
+++ b/docker.py
@@ -226,7 +226,7 @@ def ci_log_cache():
 
     src = "centos@{}:/var/log/*".format(ip)
     dest = ".mantl-ci-log/{}".format(os.environ['TF_VAR_build_number'])
-    rysnc_cmd = [
+    rsync_cmd = [
         "rsync", "--super", "-a", src, dest, 
         "-e", "ssh -i /local/ci -o BatchMode=yes -o StrictHostKeyChecking=no"
         ]

--- a/docker.py
+++ b/docker.py
@@ -218,6 +218,7 @@ def ci_log_cache():
     call("ssh-add")
     
     # parse json of tfstate for ip
+    ip = ""
     with open("terraform.tfstate") as tf:
         tfstate = json.load(tf)
         resources = [module['resources'] 
@@ -231,7 +232,7 @@ def ci_log_cache():
     dest = ".mantl-ci-log/{}".format(os.environ['TF_VAR_build_number'])
     rsync_cmd = [
         "rsync", "--super", "-a", src, dest, 
-        "-e", "ssh -i /local/ci -o BatchMode=yes -o StrictHostKeyChecking=no"
+        "-e", "ssh -i /root/.ssh/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no"
         ]
 
     exit(call(rsync_cmd))

--- a/testing/aws.tf
+++ b/testing/aws.tf
@@ -4,7 +4,7 @@ provider "aws" {
   region = "us-west-1"
 }
 
-module "aws-mantl-testing" {
+module "mantl-ci" {
   source = "./terraform/aws"
   availability_zone = "us-west-1b"
   ssh_username = "centos"

--- a/testing/build-cluster.py
+++ b/testing/build-cluster.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     setup = [
         (["terraform", "get"], 1),
         (["terraform", "plan"], 1),
-        (["terraform", "apply", "-state", "$TERRAFORM_STATE"], 1),
+        (["terraform", "apply", "-state", environ['TERRAFORM_STATE']], 1),
         (ap + ["playbooks/wait-for-hosts.yml"], 3),
         (ap + ["-e", "serial=0", "playbooks/upgrade-packages.yml"], 1),
         (ap + ["sample.yml"], 1),

--- a/testing/build-cluster.py
+++ b/testing/build-cluster.py
@@ -44,7 +44,7 @@ def run_cmds(cmds, fail_sequential=False):
 if __name__ == "__main__":
     ap = [
         "ansible-playbook", 
-        "-i", "plugins/inventory/terraform.py --root={}".format(environ['MANTL_CONFIG_DIR']),
+        "-i='plugins/inventory/terraform.py --root={}'".format(environ['MANTL_CONFIG_DIR']),
         "-e", "@security.yml", 
         "--private-key", "~/.ssh/id_rsa"
     ]

--- a/testing/build-cluster.py
+++ b/testing/build-cluster.py
@@ -42,14 +42,18 @@ def run_cmds(cmds, fail_sequential=False):
     return to_return
 
 if __name__ == "__main__":
+    for e in environ:
+        print e
     ap = [
-        "ansible-playbook", "-e", "@security.yml", "--private-key",
-        "~/.ssh/id_rsa"
+        "ansible-playbook", 
+        "-i", "plugins/inventory/terraform.py --root={}".format(environ['MANTL_CONFIG_DIR'])
+        "-e", "@security.yml", 
+        "--private-key", "~/.ssh/id_rsa"
     ]
     setup = [
         (["terraform", "get"], 1),
         (["terraform", "plan"], 1),
-        (["terraform", "apply", "-state", environ['TERRAFORM_STATE']], 1),
+        (["terraform", "apply", "-state={}".format(environ['TERRAFORM_STATE'])], 1),
         (ap + ["playbooks/wait-for-hosts.yml"], 3),
         (ap + ["-e", "serial=0", "playbooks/upgrade-packages.yml"], 1),
         (ap + ["sample.yml"], 1),

--- a/testing/build-cluster.py
+++ b/testing/build-cluster.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     setup = [
         (["terraform", "get"], 1),
         (["terraform", "plan"], 1),
-        (["terraform", "apply"], 1),
+        (["terraform", "apply", "-state", "$TERRAFORM_STATE"], 1),
         (ap + ["playbooks/wait-for-hosts.yml"], 3),
         (ap + ["-e", "serial=0", "playbooks/upgrade-packages.yml"], 1),
         (ap + ["sample.yml"], 1),

--- a/testing/build-cluster.py
+++ b/testing/build-cluster.py
@@ -42,8 +42,6 @@ def run_cmds(cmds, fail_sequential=False):
     return to_return
 
 if __name__ == "__main__":
-    for e in environ:
-        print e
     ap = [
         "ansible-playbook", 
         "-i", "plugins/inventory/terraform.py --root={}".format(environ['MANTL_CONFIG_DIR'])

--- a/testing/build-cluster.py
+++ b/testing/build-cluster.py
@@ -44,7 +44,7 @@ def run_cmds(cmds, fail_sequential=False):
 if __name__ == "__main__":
     ap = [
         "ansible-playbook", 
-        "-i", "plugins/inventory/terraform.py --root={}".format(environ['MANTL_CONFIG_DIR'])
+        "-i", "plugins/inventory/terraform.py --root={}".format(environ['MANTL_CONFIG_DIR']),
         "-e", "@security.yml", 
         "--private-key", "~/.ssh/id_rsa"
     ]

--- a/testing/do.tf
+++ b/testing/do.tf
@@ -8,7 +8,7 @@ module "do-mantl-keypair" {
   public_key_filename = "~/.ssh/id_rsa.pub"
 }
 
-module "do-mantl-hosts" {
+module "mantl-ci" {
   source = "./terraform/digitalocean/hosts"
   ssh_key = "${module.do-mantl-keypair.keypair_id}"
   region_name = "sfo1" # this must be a region with metadata support

--- a/testing/gce.tf
+++ b/testing/gce.tf
@@ -41,7 +41,7 @@ module "gce-network" {
 #}
 
 
-module "control-nodes" {
+module "mantl-ci-control-nodes" {
   source = "./terraform/gce/instance"
   count = "${var.control_count}"
   datacenter = "${var.datacenter}"
@@ -56,7 +56,7 @@ module "control-nodes" {
   zones = "${var.zones}"
 }
 
-module "edge-nodes" {
+module "mantl-ci-edge-nodes" {
   source = "./terraform/gce/instance"
   count = "${var.edge_count}"
   datacenter = "${var.datacenter}"
@@ -71,7 +71,7 @@ module "edge-nodes" {
   zones = "${var.zones}"
 }
 
-module "worker-nodes" {
+module "mantl-ci-worker-nodes" {
   source = "./terraform/gce/instance"
   count = "${var.worker_count}"
   datacenter = "${var.datacenter}"

--- a/testing/gce.tf
+++ b/testing/gce.tf
@@ -88,6 +88,6 @@ module "mantl-ci-worker-nodes" {
 
 module "network-lb" {
   source = "./terraform/gce/lb"
-  instances = "${module.edge-nodes.instances}"
+  instances = "${module.mantl-ci-edge-nodes.instances}"
   short_name = "mantl-ci-${var.build_number}"
 }


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

When a build fails on travis, we often need to inspect cluster node
logs. With these edits, we will be able to persist the logs for
inspection. First, we check to see if the build failed. If it did fail,
we use rsync in archive mode to pull down the /var/log directory from
the first control node, put it in .mantl-ci-log/<build number>, and have
travis cache that directory. The location of the cache is
https://travis-ci.org/CiscoCloud/mantl/caches