### PR TITLE
Ensure that DHCP is enabled for openstack subnets

### DIFF
--- a/terraform/openstack/network/main.tf
+++ b/terraform/openstack/network/main.tf
@@ -16,6 +16,7 @@ resource "openstack_networking_subnet_v2" "subnet" {
   cidr = "${var.subnet_cidr}"
   ip_version = "${var.ip_version}"
   dns_nameservers = ["${compact(split(\",\", var.dns_nameservers))}"]
+  enable_dhcp = true
 }
 
 resource "openstack_networking_router_v2" "router" {


### PR DESCRIPTION
- [X] Installs cleanly on a fresh build of most recent master branch
- [X] Upgrades cleanly from the most recent release
- [X] Updates documentation relevant to the changes

We came across an openstack DC that didn't support
this and caused instances to never get IPs.

On existing openstack subnets, it will change the dhcp flag if it is set to false. 