### PR TITLE
Ensure Openstack block storage matches hostname

### DIFF
--- a/terraform/openstack/instance/main.tf
+++ b/terraform/openstack/instance/main.tf
@@ -18,8 +18,8 @@ variable volume_device { default = "/dev/vdb" }
 variable user_data { default = "" }
 
 resource "openstack_blockstorage_volume_v1" "blockstorage" {
-  name = "${var.name}-${format(var.count_format, var.count_offset+count.index+1) }"
-  description = "${var.name}-${format(var.count_format, var.count_offset+count.index+1) }"
+  name = "${var.name}-${var.role}-${format(var.count_format, var.count_offset+count.index+1) }"
+  description = "${var.name}-${var.role}-${format(var.count_format, var.count_offset+count.index+1) }"
   size = "${var.volume_size}"
   metadata = {
     attached_mode = "${var.blockstorage_metadata_attached_mode}"


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

This makes openstack blockstorage devices created by
terraform match the hosts they are attached to.