### PR TITLE
Eliminate a race where a mesos agent could not connect to the master

### DIFF
--- a/roles/mesos/files/mesos-leader-iptables.tmpl
+++ b/roles/mesos/files/mesos-leader-iptables.tmpl
@@ -9,15 +9,9 @@ iptables -X MESOSLEADER
 
 {{ if not $mesosLeaderIpTables }}exit 0{{ end }}
 
-{{ if or (eq 0 (len (service "master.mesos" "any"))) (eq 0 (len (service "follower.mesos" "any"))) }}exit 0
-{{ end }}
-
 iptables -N MESOSLEADER
 
-{{ range service "master.mesos" "any" }}
-iptables -A MESOSLEADER -p tcp --dport {{ $mesosLeaderPort }} -s {{ .Address }} -j ACCEPT
-{{ end }}
-{{ range service "follower.mesos" "any" }}
+{{ range nodes }}
 iptables -A MESOSLEADER -p tcp --dport {{ $mesosLeaderPort }} -s {{ .Address }} -j ACCEPT
 {{ end }}
 iptables -A MESOSLEADER -p tcp --dport {{ $mesosLeaderPort }} -d 127.0.0.1 -j ACCEPT


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

When adding a worker node to an existing cluster, the previous iptables
template would block the new worker node from registering with the master.