### PR TITLE
Updated vSphere Support to Master and add Kubernetes

### DIFF
--- a/docs/getting_started/vsphere.rst
+++ b/docs/getting_started/vsphere.rst
@@ -11,6 +11,7 @@ Terraform
 
 Install Terraform according to the `guide <https://www.terraform.io/intro/getting-started/install.html>`_.
 
+*Note: Minimum Terraform version of 0.6.16 required to leverage some newer features of the vSphere provider*
 
 VMware template
 ^^^^^^^^^^^^^^^^^
@@ -49,6 +50,10 @@ Basic settings
 
 ``network_label`` is the label of the network assigned to the machines.
 
+``domain`` is the domain name to configure each host with. 
+
+``dns_server1`` & ``dns_server2`` are the dns servers to configure on the hosts.
+
 ``short_name`` is the prefix that will be used for the new virtual machines.
 
 ``ssh_user`` is the username for the further service provisioning. This user has to be in the sudoers group with NOPASSWD option.
@@ -74,22 +79,23 @@ Microservices settings
 Optional settings
 ^^^^^^^^^^^^^^^^^^^
 
-There are several optional settings that can be leveraged in the sample terraform file.  Just uncomment the line and configure the desired value.  
+There are several optional settings that can be leveraged in the sample terraform file.  Just uncomment the line and configure the desired value.
 
-``folder`` set this to the name of a folder to place the new virtual machines into under the Datacenter object.  Folder must exist already.  
+``folder`` set this to the name of a folder to place the new virtual machines into under the Datacenter object.  Folder must exist already.
 
-``control_cpu`` is the number of vCPUs to deploy for control nodes.  
+``control_cpu`` is the number of vCPUs to deploy for control nodes.
 
-``worker_cpu`` is the number of vCPUs to deploy for worker nodes.  
+``worker_cpu`` is the number of vCPUs to deploy for worker nodes.
 
-``edge_cpu`` is the number of vCPUs to deploy for edge nodes.  
+``edge_cpu`` is the number of vCPUs to deploy for edge nodes.
 
-``control_ram`` is the amount of vRAM in MBs to deploy for control nodes.  
+``control_ram`` is the amount of vRAM in MBs to deploy for control nodes.
 
-``worker_ram`` is the number of vRAM in MBs to deploy for worker nodes.  
+``worker_ram`` is the number of vRAM in MBs to deploy for worker nodes.
 
-``edge_ram`` is the number of vRAM in MBs to deploy for edge nodes.  
+``edge_ram`` is the number of vRAM in MBs to deploy for edge nodes.
 
+``linked_clone`` setting this to true will deploy the VMs as linked clones.  Default of false will create standard full clones for each VM.  Note that performance of linked clones is dependent on the underlying servers and storage.  In some cases linked_clone deployments have failed during installation where full clones work fine.  If you get errors during the installation on a linked_clone setup, try using full clones and see if that fixes the error.   
 
 Advanced settings
 ^^^^^^^^^^^^^^^^^^^
@@ -107,4 +113,3 @@ Due to a timing condition when requesting a MAC address from the vsphere server 
 Afterwards, you can
 use the instructions in :doc:`getting started <index>` to install
 Mantl on your new cluster.
-

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -18,10 +18,6 @@
   tags:
     - common
 
-- name: ensure cloud.cfg.d directory exists
-  sudo: yes
-  file: path=/etc/cloud/cloud.cfg.d state=directory recurse=yes owner=root group=root mode=0644
-
 - name: preserve hostname
   sudo: yes
   copy:
@@ -33,7 +29,8 @@
   when: >
     provider != "bare-metal" and
     provider != "virtualbox" and
-    provider != "packer"
+    provider != "packer" and 
+    provider != "vsphere" 
   tags:
     - common
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -18,6 +18,10 @@
   tags:
     - common
 
+- name: ensure cloud.cfg.d directory exists
+  sudo: yes
+  file: path=/etc/cloud/cloud.cfg.d state=directory recurse=yes owner=root group=root mode=0644
+
 - name: preserve hostname
   sudo: yes
   copy:

--- a/terraform/vsphere.sample.tf
+++ b/terraform/vsphere.sample.tf
@@ -14,10 +14,14 @@ module "vsphere-dc" {
   pool = "" # format is cluster_name/Resources/pool_name
   template = ""
   network_label = ""
+  domain = ""
+  dns_server1 = ""
+  dns_server2 = ""
   datastore = ""
   control_count = 3
   worker_count = 4
   edge_count = 2
+  kubeworker_count = 0
   control_volume_size = 20 # size in gigabytes
   worker_volume_size = 20
   edge_volume_size = 20
@@ -33,5 +37,6 @@ module "vsphere-dc" {
   #control_ram = ""
   #worker_ram = ""
   #edge_ram = ""
-  #disk_type = "" thin or eager_zeored, default is thin
+  #disk_type = "" # thin or eager_zeored, default is thin
+  #linked_clone = "" # true or false, default is false.  If using linked_clones and have problems installing Mantl, revert to full clones 
 }

--- a/terraform/vsphere/main.tf
+++ b/terraform/vsphere/main.tf
@@ -2,6 +2,7 @@ variable "datacenter" {}
 variable "cluster" {}
 variable "pool" {}
 variable "template" {}
+variable "linked_clone" { default = false }
 variable "ssh_user" {}
 variable "ssh_key" {}
 variable "consul_dc" {}
@@ -27,6 +28,10 @@ variable "control_ram" { default = 4096 }
 variable "worker_ram" { default = 4096 }
 variable "edge_ram" { default = 4096 }
 
+variable "domain" { default = "" }
+variable "dns_server1" { default = "" }
+variable "dns_server2" { default = "" }
+
 resource "vsphere_virtual_machine" "mi-control-nodes" {
   name = "${var.short_name}-control-${format("%02d", count.index+1)}"
   datacenter = "${var.datacenter}"
@@ -36,6 +41,8 @@ resource "vsphere_virtual_machine" "mi-control-nodes" {
 
   vcpu = "${var.control_cpu}"
   memory = "${var.control_ram}"
+
+  linked_clone = "${var.linked_clone}"
 
   disk {
     size = "${var.control_volume_size}"
@@ -47,6 +54,9 @@ resource "vsphere_virtual_machine" "mi-control-nodes" {
   network_interface {
     label = "${var.network_label}"
   }
+
+  domain = "${var.domain}"
+  dns_servers = ["${var.dns_server1}", "${var.dns_server2}"]
 
   custom_configuration_parameters = {
     role = "control"
@@ -76,6 +86,8 @@ resource "vsphere_virtual_machine" "mi-worker-nodes" {
 
   vcpu = "${var.worker_cpu}"
   memory = "${var.worker_ram}"
+  
+  linked_clone = "${var.linked_clone}"
 
   disk {
     size = "${var.worker_volume_size}"
@@ -87,6 +99,9 @@ resource "vsphere_virtual_machine" "mi-worker-nodes" {
   network_interface {
     label = "${var.network_label}"
   }
+
+  domain = "${var.domain}"
+  dns_servers = ["${var.dns_server1}", "${var.dns_server2}"]
 
   custom_configuration_parameters = {
     role = "worker"
@@ -118,6 +133,8 @@ resource "vsphere_virtual_machine" "mi-kubeworker-nodes" {
   vcpu = "${var.worker_cpu}"
   memory = "${var.worker_ram}"
 
+  linked_clone = "${var.linked_clone}"
+
   disk {
     size = "${var.worker_volume_size}"
     template = "${var.template}"
@@ -129,7 +146,10 @@ resource "vsphere_virtual_machine" "mi-kubeworker-nodes" {
     label = "${var.network_label}"
   }
 
-  configuration_parameters = {
+  domain = "${var.domain}"
+  dns_servers = ["${var.dns_server1}", "${var.dns_server2}"]
+
+  custom_configuration_parameters = {
     role = "kubeworker"
     ssh_user = "${var.ssh_user}"
     consul_dc = "${var.consul_dc}"
@@ -158,6 +178,8 @@ resource "vsphere_virtual_machine" "mi-edge-nodes" {
   vcpu = "${var.edge_cpu}"
   memory = "${var.edge_ram}"
 
+  linked_clone = "${var.linked_clone}"
+
   disk {
     size = "${var.edge_volume_size}"
     template = "${var.template}"
@@ -168,6 +190,9 @@ resource "vsphere_virtual_machine" "mi-edge-nodes" {
   network_interface {
     label = "${var.network_label}"
   }
+
+  domain = "${var.domain}"
+  dns_servers = ["${var.dns_server1}", "${var.dns_server2}"]
 
   custom_configuration_parameters = {
     role = "edge"
@@ -197,7 +222,7 @@ output "worker_ips" {
 }
 
 output "kubeworker_ips" {
-  value = "${join(\",\", vsphere_virtual_machine.mi-kubeworker-nodes.*.network_interface.ip_address)}"
+  value = "${join(\",\", vsphere_virtual_machine.mi-kubeworker-nodes.*.network_interface.ipv4_address)}"
 }
 
 output "edge_ips" {


### PR DESCRIPTION
I've updated the vSphere provider code for: 

- to support Kubernetes 
- tested against the latest master branch 
- added support for linked-clones in vSphere (with caveats related to production, default still full clone) 
- updated vSphere Getting Started Doc 
- Fixed issue with directory cloud.cfg.d not getting created on providers without cloud init

- [x] Installs cleanly on a fresh build of most recent master branch
- [n/a] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes