### PR TITLE
Remove -tls-skip-verify from vault commands

### DIFF
--- a/roles/vault/README.rst
+++ b/roles/vault/README.rst
@@ -17,12 +17,6 @@ Variables
 
    default: ``8200``
 
-.. data:: vault_command_options
-
-   Extra options to pass to Vault at startup
-
-   default: ``-insecure``
-
 .. data:: vault_init_json
 
    Initial JSON configuration for Vault

--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 vault_package: vault-0.4.1
 vault_default_port: 8200
-vault_command_options: -tls-skip-verify
 
 vault_init_json: '{
 	"secret_shares": 5,

--- a/roles/vault/templates/vault.unseal.j2
+++ b/roles/vault/templates/vault.unseal.j2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{% for key in vault_keys %}vault unseal {{ vault_command_options }} {{ key }}
+{% for key in vault_keys %}vault unseal {{ key }}
 {% endfor %}
 
 exit 0


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

There's probably no reason to do this, our certificates are set up properly. 