### PR TITLE
provider/openstack: add ssh_user to kubeworker module

### DIFF
--- a/terraform/openstack-modules.sample.tf
+++ b/terraform/openstack-modules.sample.tf
@@ -116,6 +116,7 @@ module "instances-kubeworker" {
   keypair_name = "${module.ssh-key.keypair_name}"
   flavor_name = "${var.kubeworker_flavor_name}"
   image_name = "${var.image_name}"
+  ssh_user = "${var.ssh_user}"
 }
 
 module "instances-edge" {


### PR DESCRIPTION
fixes #1488 

- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

