### PR TITLE
fix upgrade playbook for mixed clusters

### DIFF
--- a/playbooks/upgrade-1.0.3.yml
+++ b/playbooks/upgrade-1.0.3.yml
@@ -55,6 +55,7 @@
       file:
         path: /etc/collectd.d/docker.conf
         state: absent
+      notify: restart collectd
 
     - name: install mantl-dns
       sudo: yes
@@ -67,14 +68,19 @@
       shell: stat /etc/dnsmasq.d/10-consul.rpmnew && mv /etc/dnsmasq.d/10-consul.rpmnew /etc/dnsmasq.d/10-consul
       failed_when: false
 
-    - name: restart services
+    - name: restart nginx-consul
       become: yes
       service:
-        name: "{{ item }}"
+        name: nginx-consul
         state: restarted
-      with_items:
-        - nginx-consul
-        - collectd
+
+  handlers:
+
+    - name: restart collectd
+      become: yes
+      service:
+        name: collectd
+        state: restarted
 
 - hosts: role=control
   serial: "{{ serial | default(1) }}"


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch n/a
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes n/a

this fixes a scenario where the upgrade playbook would fail if you have a cluster with mixed 1.0.3 and 1.1 nodes. collectd does not run (by default) on 1.1 nodes and the upgrade would fail if run against those nodes.