### PR TITLE
ANSIBLE remove yum refresh from upgrade playbook

### DIFF
--- a/playbooks/rolling-upgrade-packages.yml
+++ b/playbooks/rolling-upgrade-packages.yml
@@ -10,12 +10,6 @@
     tags:
       - skip_ansible_lint
 
-  - name: refresh yum cache
-    sudo: yes
-    command: yum makecache
-    tags:
-      - skip_ansible_lint
-
   - name: upgrade kernel package
     sudo: yes
     yum:


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

When you run the rolling-upgrade-packages playbook, the yum refresh
cache task can time out, causing the playbook to fail. This in turn
causes CI tests to fail, and makes more work for our users.

I had this branch ready to go for some time, but I didn't make a PR. Sorry for that.