### PR TITLE
TRAVIS DOCKER Install bash for provisioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM alpine:3.3
 
-RUN apk add --no-cache build-base curl git openssh openssl py-pip python python-dev unzip \
+RUN apk add --no-cache bash build-base curl git libffi-dev openssh openssl-dev py-pip python python-dev unzip \
 	&& git clone https://github.com/CiscoCloud/mantl /mantl \
-	&& apk add --no-cache build-base python-dev py-pip \
 	&& pip install -r /mantl/requirements.txt \
 	&& apk del build-base python-dev py-pip
 


### PR DESCRIPTION
There are some provisioning scripts used within ansible that require
bash syntax in order to run. Previously, I didn't install bash in the
container because we were trying to keep the image simpler. However,
if we don't include bash, that means we have to refactor scripts to be
sh compatible, and that is not a good trade-off.