### PR TITLE
external wildcard tls certs

### DIFF
--- a/playbooks/c12e_customize.yml
+++ b/playbooks/c12e_customize.yml
@@ -1,0 +1,41 @@
+# c12e_customize.yml
+
+- hosts: all
+  sudo: yes
+  vars: 
+    # a directory where you keep configuration of mantl projects
+    mantl_config_dir: ~/projects/mantl-config
+    wildcard_certs_dir: "{{mantl_config_dir}}/example.com.certs"
+    use_wildcard_certs: "yes"
+  tasks:
+    - debug: msg="{{mantl_config_dir}}"
+
+    - name: install some basics
+      yum:
+        name: "{{item}}"
+      with_items:
+        - nano
+        - telnet
+
+
+    - include: wildcard_ssl.yml
+      when: (use_wildcard_certs == 'yes')
+
+# These are touch-ups for special cases.
+# should be templatized on wildcard cert names.
+
+    # - name: concatenate CA and wildcard.cert for traefik
+    #   sudo: yes
+    #   shell: cat /public_certs/wildcard.c1.io.cert.pem /public_certs/geoTrust_CA_Chain.cert.pem  > /public_certs/wildcard-chain.c1.io.cert.pem
+
+    # - name: concatenate private key with cert for mongo
+    #   sudo: yes
+    #   shell: cat /private_certs/container.key.pem /public_certs/container.cert.pem > /private_certs/mongo.container.key.pem
+    #   when: inventory_hostname in groups['role=worker']
+
+    # - name: concatenate CA and container.cert for mongo
+    #   sudo: yes
+    #   shell: cat /public_certs/container.cert.pem /public_certs/ca.cert.pem > /public_certs/ca-chain.cert.pem
+    #   when: inventory_hostname in groups['role=worker']
+
+

--- a/playbooks/wildcard_ssl.yml
+++ b/playbooks/wildcard_ssl.yml
@@ -1,5 +1,26 @@
 ---
 
+# TODO
+# /private_certs and /public/certs should be variables
+
+# This should probably be split into two files
+# The first in [optional edit to ] roles/common/tasks/ssl.yml to place 
+# the files into a standard  place on the host where containers can mount them.
+# Motivation: the location of these files has 
+# changed several times and may be os dependent.  Companies may have conventions
+# for locations for security reasons.
+
+# The second in roles/traefik/tasks/routed_certs.yml is to copy wildcard certs 
+# to traefik edge nodes to handle external
+# termination.  At the moment, the wildcards are added to all nodes.  It might be useful
+# for controller nodes so that we can have a verified cert for the mantlui.
+# It is unlikely the worker nodes would need them unless the workers were publicly routable.
+
+
+###########################################
+# move self-signed CA certs into place
+###########################################
+
 - name: make the cert directories
   sudo: yes
   file: 
@@ -10,7 +31,7 @@
     - /private_certs
     - /public_certs
 
-- name: copy container keys and certs into place
+- name: copy CA cert into place
   sudo: yes
   copy:
     src: "{{ item.src }}"
@@ -19,10 +40,21 @@
   with_items:
     - src: ../ssl/cacert.pem
       dest: /public_certs/ca.cert.pem
-    - src: ../ssl/certs/host.cert.pem
+
+- name: copy container keys and certs into place
+  sudo: yes
+  shell: cp "{{ item.src }}" "{{ item.dest }}"
+  with_items:
+    - src: /etc/pki/mantl/cert
       dest: /public_certs/container.cert.pem
-    - src: ../ssl/private/host.key.pem
+    - src: /etc/pki/mantl/key
       dest: /private_certs/container.key.pem
+
+
+###########################################
+# move 3rd party wildcard certs into place
+# (these could conceivably be letsencrypt HA certs too)
+###########################################
 
 - name: copy public wildcard certs to /public_certs
   sudo: yes
@@ -34,6 +66,7 @@
   with_fileglob: 
     - "{{ wildcard_certs_dir }}/public_certs/*"
 
+# This step may be un-necessary.  Determine minimal required.
 - name: copy public wildcard certs to /etc/pki/CA/
   sudo: yes
   copy:
@@ -64,6 +97,26 @@
   with_fileglob:
     - "{{ wildcard_certs_dir }}/private_certs/*"
 
+- name: ensure ssl_services group exists
+  group:
+    name: ssl_services
+    state: present
+
+- name: on edge nodes make traefik owner of /private_certs
+  sudo: yes
+  file:
+    state: directory
+    dest: "/private_certs"
+    owner: traefik
+    mode: 0440
+    recurse: yes
+  with_fileglob:
+    - 
+  when: inventory_hostname in groups['role=edge']
+
+- name: set group owner to ssl_services
+    group: ssl_services
+
 - name: copy wildcard private keys to /etc/pki/tls/private
   sudo: yes
   copy:
@@ -73,15 +126,23 @@
   with_fileglob:
     - "{{ wildcard_certs_dir }}/private_certs/*"
 
-- name: copy wildcard private keys to /etc/pki/CA/
-  sudo: yes
-  copy:
-    src: "{{ item }}"
-    dest: "/etc/pki/CA/{{ item | basename }}"
-    owner: root
-    mode: 0400
-  with_fileglob:
-    - "{{ wildcard_certs_dir }}/private_certs/*"
+# Only needed if servers in mantl cluster need to hit external endpoints
+# For example, to run health-checks on exposed enpoints
+# - name: copy wildcard private keys to /etc/pki/CA/
+#   sudo: yes
+#   copy:
+#     src: "{{ item }}"
+#     dest: "/etc/pki/CA/{{ item | basename }}"
+#     owner: root
+#     mode: 0400
+#   with_fileglob:
+#     - "{{ wildcard_certs_dir }}/private_certs/*"
 
 - name: update-ca-trust
   shell: update-ca-trust
+
+# This should be moved to traefik/handlers/main.yml if placed in a role
+- name: restart traefik
+  service:
+    name: traefik
+    state: restarted

--- a/playbooks/wildcard_ssl.yml
+++ b/playbooks/wildcard_ssl.yml
@@ -1,0 +1,87 @@
+---
+
+- name: make the cert directories
+  sudo: yes
+  file: 
+    state: directory
+    dest: "{{ item }}"
+    mode: 0755
+  with_items:
+    - /private_certs
+    - /public_certs
+
+- name: copy container keys and certs into place
+  sudo: yes
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: root
+  with_items:
+    - src: ../ssl/cacert.pem
+      dest: /public_certs/ca.cert.pem
+    - src: ../ssl/certs/host.cert.pem
+      dest: /public_certs/container.cert.pem
+    - src: ../ssl/private/host.key.pem
+      dest: /private_certs/container.key.pem
+
+- name: copy public wildcard certs to /public_certs
+  sudo: yes
+  copy:
+    src: "{{ item }}"
+    dest: "/public_certs/{{ item | basename }}"
+    owner: root
+    mode: 0644
+  with_fileglob: 
+    - "{{ wildcard_certs_dir }}/public_certs/*"
+
+- name: copy public wildcard certs to /etc/pki/CA/
+  sudo: yes
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/pki/CA/{{ item | basename }}"
+    owner: root
+    mode: 0644
+  with_fileglob:
+    - "{{ wildcard_certs_dir }}/public_certs/*"
+
+- name: copy public wildcard certs to truststore /etc/pki/ca-trust/source/anchors/
+  sudo: yes
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/pki/ca-trust/source/anchors/{{ item | basename }}"
+    owner: root
+    mode: 0644
+  with_fileglob:
+    - "{{ wildcard_certs_dir }}/public_certs/*"
+
+- name: copy wildcard private keys to /private_certs
+  sudo: yes
+  copy:
+    src: "{{ item }}"
+    dest: "/private_certs/{{ item | basename }}"
+    owner: root
+    mode: 0400
+  with_fileglob:
+    - "{{ wildcard_certs_dir }}/private_certs/*"
+
+- name: copy wildcard private keys to /etc/pki/tls/private
+  sudo: yes
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/pki/tls/private/{{ item | basename }}"
+    mode: 0400
+  with_fileglob:
+    - "{{ wildcard_certs_dir }}/private_certs/*"
+
+- name: copy wildcard private keys to /etc/pki/CA/
+  sudo: yes
+  copy:
+    src: "{{ item }}"
+    dest: "/etc/pki/CA/{{ item | basename }}"
+    owner: root
+    mode: 0400
+  with_fileglob:
+    - "{{ wildcard_certs_dir }}/private_certs/*"
+
+- name: update-ca-trust
+  shell: update-ca-trust

--- a/playbooks/wildcard_ssl.yml
+++ b/playbooks/wildcard_ssl.yml
@@ -110,12 +110,23 @@
     owner: traefik
     mode: 0440
     recurse: yes
-  with_fileglob:
-    - 
   when: inventory_hostname in groups['role=edge']
 
-- name: set group owner to ssl_services
+- name: on all nodes make ssl_services group owner of /private_certs
+  sudo: yes
+  file:
+    state: directory
+    dest: "/private_certs"
     group: ssl_services
+    mode: 0440
+    recurse: yes
+
+- name: on all nodes make /private_certs 0551
+  sudo: yes
+  file:
+    state: directory
+    dest: "/private_certs"
+    mode: 0551
 
 - name: copy wildcard private keys to /etc/pki/tls/private
   sudo: yes
@@ -146,3 +157,4 @@
   service:
     name: traefik
     state: restarted
+  when: inventory_hostname in groups['role=edge']

--- a/roles/traefik/templates/traefik.toml.j2
+++ b/roles/traefik/templates/traefik.toml.j2
@@ -1,8 +1,41 @@
+# {{ansible_managed}}
+
 port = ":80"
 graceTimeOut = 10
-logLevel = "ERROR"
+logLevel = "{{ traefik_loglevel }}"
+
+{% if traefik_log_path %}
+accessLogsFile = "{{ traefik_access_log_path }}"
+{% endif %}
+
+{% if traefik_access_log_path %}
+traefikLogsFile = "{{traefik_log_path}}"
+{% endif %}
+
+{% if traefik_routed_cert_path %}
+defaultEntryPoints = ["http", "https"]
+[entryPoints]
+  [entryPoints.http]
+  address = ":80"
+    [entryPoints.http.redirect]
+    entryPoint = "https"
+  [entryPoints.https]
+  address = ":443"
+    [entryPoints.https.tls]
+      [[entryPoints.https.tls.certificates]]
+      certFile = "{{ traefik_routed_cert_path }}"
+      keyFile = "{{ traefik_routed_key_path }}"
+{% endif %}
+
+{% if traefik_retry_attempts %}
+[retry]
+# default is -1 -> the number of backends for a frontend
+attempts = {{traefik_retry_attempts | int }}
+{% endif %}
 
 [web]
+# The key and cert here are for accessing the web ui over ssl
+# They do not affect routed traffic to the back end 
 address = ":8081"
 CertFile = "/etc/pki/tls/certs/host.cert"
 KeyFile = "/etc/pki/tls/private/host.key"


### PR DESCRIPTION
This is a temporary standalone alternative to
https://github.com/CiscoCloud/mantl/pull/1445/files
which integrates the traefik.toml file into the traefik role.


- [ ] Installs cleanly on a fresh build of most recent master branch
- [ ] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes
