### PR TITLE
Ensure package removal url is only one line

### DIFF
--- a/roles/elasticsearch/tasks/uninstall.yml
+++ b/roles/elasticsearch/tasks/uninstall.yml
@@ -3,7 +3,7 @@
   sudo: no
   run_once: yes
   register: mantl_api_url
-  shell: consul-cli catalog-service mantl-api | jq -r '.[] | .ServiceAddress + ":" + (.ServicePort|tostring)'
+  shell: consul-cli catalog-service mantl-api | jq -r '.[0] | .ServiceAddress + ":" + (.ServicePort|tostring)'
   tags:
     - elasticsearch
 

--- a/roles/kibana/tasks/uninstall.yml
+++ b/roles/kibana/tasks/uninstall.yml
@@ -3,7 +3,7 @@
   sudo: no
   run_once: yes
   register: mantl_api_url
-  shell: consul-cli catalog-service mantl-api | jq -r '.[] | .ServiceAddress + ":" + (.ServicePort|tostring)'
+  shell: consul-cli catalog-service mantl-api | jq -r '.[0] | .ServiceAddress + ":" + (.ServicePort|tostring)'
   tags:
     - kibana
 


### PR DESCRIPTION
Fixes a bug where multiple mantl ui instances causes the curl -X DELETE task to fail due to multiple urls being present in mantl_api_url.stdout. Instead we choose the first. 
