### PR TITLE
Consistent kibana elasticsearch-http value

### DIFF
--- a/roles/elasticsearch/README.rst
+++ b/roles/elasticsearch/README.rst
@@ -89,7 +89,7 @@ uninstall:
 
 .. code-block:: shell
 
-   ansible-playbook -e @security.yml -e 'elasticsearch_uninstall=true elasticsearch_remove_data=true' addons/elk-uninstall.yml
+   ansible-playbook -e @security.yml -e 'elasticsearch_uninstall=true elasticsearch_remove_data=true' addons/elasticsearch.yml
 
 Uninstalling the Elasticsearch Framework (1.0.3)
 ------------------------------------------------

--- a/roles/kibana/templates/kibana-mesos.json.j2
+++ b/roles/kibana/templates/kibana-mesos.json.j2
@@ -4,6 +4,7 @@
     "kibana-mesos": {
       "id": "{{ kibana_mesos_id }}",
       "framework-name": "{{ kibana_mesos_framework_name }}",
+      "elasticsearch-http": "http://{{ kibana_mesos_elasticsearch_service }}.service.consul:9200",
       "scheduler": {
         "cpu": {{ kibana_mesos_scheduler_cpu }},
         "ram": {{ kibana_mesos_scheduler_ram }}


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

---

this does not actually affect functionality but, to avoid confusion, makes the elasticsearch-http value consistent with the actual configuration value used in the ELASTICSEARCH_SERVICE environment variable. see #1544