### PR TITLE
traefik: fixes traefik ui

### DIFF
--- a/roles/mantlui/defaults/main.yml
+++ b/roles/mantlui/defaults/main.yml
@@ -1,4 +1,4 @@
 mantlui_nginx_image: ciscocloud/nginx-mantlui
-mantlui_nginx_image_tag: 0.6.8
+mantlui_nginx_image_tag: 0.6.9
 do_mantlui_ssl: false
 do_mantlui_auth: false


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

currently, the traefik ui renders without any styles. The updated mantlui fixes this. This will need to be updated again when we incorporate the next traefik release.