### PR TITLE
elk: increase default resources

### DIFF
--- a/roles/elasticsearch/README.rst
+++ b/roles/elasticsearch/README.rst
@@ -30,8 +30,8 @@ Default Configuration
 ---------------------
 
 The default configuration of the Elasticsearch cluster will require at least 4
-worker nodes, each having at least 1 full CPU and 1 GB of memory available to
-Mesos. In addition, each worker node will need to have at least 5 GBs of free
+worker nodes, each having at least 1 full CPU and 2+ GBs of memory available to
+Mesos. In addition, each worker node will need to have at least 10 GBs of free
 disk space.
 
 While a cluster of this size will be sufficient to evaluate and test
@@ -143,14 +143,14 @@ Variables
    The amount of memory to allocate to each Elasticsearch executor instance
    (MB).
 
-   default: 1024
+   default: 2048
 
 .. data:: elasticsearch_disk
 
    The amount of Disk resource to allocate to each Elasticsearch executor
    instance (MB).
 
-   default: 5120
+   default: 10240
 
 .. data:: elasticsearch_cpu
 
@@ -196,7 +196,7 @@ Variables
 
    The version of the Elasticsearch mesos framework. 
 
-   default: "1.0.1"
+   default: "1.0.1-1"
 
 .. data:: elasticsearch_framework_name
 
@@ -255,7 +255,7 @@ Variables
 
    The amount of memory to allocate to the Elasticsearch client node (MB).
 
-   default: 1024
+   default: 2048
 
 .. data:: elasticsearch_client_java_opts
 

--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -2,15 +2,15 @@
 # elasticsearch framework
 elasticsearch_java_opts: "-Xms1g -Xmx1g"
 elasticsearch_ram: 1024
-elasticsearch_executor_ram: 1024
-elasticsearch_disk: 5120
+elasticsearch_executor_ram: 2048
+elasticsearch_disk: 10240
 elasticsearch_cpu: 1.0
 elasticsearch_executor_cpu: 1.0
 elasticsearch_nodes: 3
 elasticsearch_cluster_name: mantl
 elasticsearch_service: elasticsearch-mantl
 elasticsearch_executor_name: elasticsearch-executor-mantl
-elasticsearch_framework_version: 1.0.1
+elasticsearch_framework_version: 1.0.1-1
 elasticsearch_framework_name: mantl/elasticsearch
 elasticsearch_framework_ui_port: 31100
 
@@ -21,7 +21,7 @@ elasticsearch_client_elasticsearch_service: transport_port.{{ elasticsearch_exec
 elasticsearch_client_client_port: 9200
 elasticsearch_client_transport_port: 9300
 elasticsearch_client_cpu: 1
-elasticsearch_client_ram: 1024
+elasticsearch_client_ram: 2048
 elasticsearch_client_java_opts: "-Xms1g -Xmx1g"
 
 es_packages:

--- a/roles/kibana/README.rst
+++ b/roles/kibana/README.rst
@@ -111,13 +111,13 @@ Variables
 
    The amount of CPU resources to allocate to each Kibana instance (Kibana on Marathon).
 
-   default: 0.5
+   default: 1.0
 
 .. data:: kibana_ram
 
    The amount of memory to allocate to each instance of Kibana (MB) (Kibana on Marathon).
 
-   default: 512
+   default: 1024
 
 .. data:: kibana_instances
 
@@ -172,28 +172,28 @@ Variables
    The amount of CPU resources to allocate to the Kibana framework scheduler
    (Kibana Mesos framework).
 
-   default: 0.2
+   default: 0.5
 
 .. data:: kibana_mesos_scheduler_ram
 
    The amount of memory to allocate to the Kibana framework scheduler (MB)
    (Kibana Mesos framework).
 
-   default: 256
+   default: 512
 
 .. data:: kibana_mesos_executor_cpu
 
    The amount of CPU resources to allocate to each Kibana executor instance
    (Kibana Mesos framework).
 
-   default: 0.5
+   default: 1.0
 
 .. data:: kibana_mesos_executor_ram
 
    The amount of memory to allocate to each Kibana executor instance (MB)
    (Kibana Mesos framework).
 
-   default: 512
+   default: 1024
 
 .. data:: kibana_mesos_instances
 

--- a/roles/kibana/defaults/main.yml
+++ b/roles/kibana/defaults/main.yml
@@ -9,8 +9,8 @@ kibana_id: mantl/kibana
 kibana_service: kibana-mantl
 kibana_image: ciscocloud/mantl-kibana:4.3.2.1
 kibana_elasticsearch_service: elasticsearch-client-mantl
-kibana_cpu: 0.5
-kibana_ram: 512
+kibana_cpu: 1.0
+kibana_ram: 1024
 kibana_instances: 1
 
 # kibana mesos framework
@@ -20,10 +20,10 @@ kibana_mesos_service: kibana-mantl
 kibana_mesos_image: ciscocloud/mantl-kibana:4.3.2.1
 kibana_mesos_elasticsearch_service: elasticsearch-client-mantl
 kibana_mesos_kibana_service: "{{ kibana_mesos_framework_name }}-task"
-kibana_mesos_scheduler_cpu: 0.2
-kibana_mesos_scheduler_ram: 256
-kibana_mesos_executor_cpu: 0.5
-kibana_mesos_executor_ram: 512
+kibana_mesos_scheduler_cpu: 0.5
+kibana_mesos_scheduler_ram: 512
+kibana_mesos_executor_cpu: 1.0
+kibana_mesos_executor_ram: 1024
 kibana_mesos_instances: 1
 
 kibana_packages:


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

---

Increase the resources allocated for elasticsearch and kibana with the default configuration. Same testing process as #1481 but with a cluster that has sufficient resources.

I'm not sure what the correct balance is between providing a default configuration that doesn't require a huge investment in compute resources vs a configuration that might be appropriate for real workloads. Feedback welcome.