### PR TITLE
Added support for integrating a new Mantl Worker with an existing Mantl cluster

### DIFF
--- a/roles/common/templates/hosts.j2
+++ b/roles/common/templates/hosts.j2
@@ -5,3 +5,8 @@
 {{ hostvars[item].private_ipv4 }} {% if use_host_domain %}{{ item }}.{{ host_domain }}{% endif %} {{ item }}
 {% endif %}
 {% endfor %}
+{% if hosts_core_override is defined %}
+{% for host in hosts_core_override %}
+{{ host.private_ipv4 }} {{ host.hostname }}
+{% endfor %}
+{% endif %}

--- a/roles/consul/defaults/main.yml
+++ b/roles/consul/defaults/main.yml
@@ -7,10 +7,9 @@ consul_dc_group: dc={{ consul_dc }}
 consul_servers_group: role=control
 consul_log_level: "warn"
 consul_is_server: "{{ consul_servers_group in group_names }}"
-consul_controller_override: "{{ consul_servers_group in groups }}"
 consul_advertise: "{{ private_ipv4 }}"
-consul_retry_join: "{% if not consul_controller_override %}{% for host in groups[consul_servers_group] | intersect(groups[consul_dc_group]) %}\"{{ hostvars[host].private_ipv4 }}\"{% if not loop.last %},{% endif %}{% endfor %}{% endif %}{% if consul_controller_override  %}{% for controller in consul_servers_group_override %}\"{{ controller }}\"{% if not loop.last %},{% endif %} {% endfor%} {% endif %}"
-consul_bootstrap_expect: "{% if not consul_controller_override %}{{ groups[consul_servers_group] | intersect(groups[consul_dc_group]) | length }}{% endif %}"
+consul_retry_join: "{% if consul_servers_group_override is not defined %}{% for host in groups[consul_servers_group] | intersect(groups[consul_dc_group]) %}\"{{ hostvars[host].private_ipv4 }}\"{% if not loop.last %},{% endif %}{% endfor %}{% endif %}{% if consul_servers_group_override is defined  %}{% for controller in consul_servers_group_override %}\"{{ controller }}\"{% if not loop.last %},{% endif %} {% endfor%} {% endif %}"
+consul_bootstrap_expect: "{% if consul_servers_group_override is not defined %}{{ groups[consul_servers_group] | intersect(groups[consul_dc_group]) | length }}{% endif %}"
 consul_disable_remote_exec: yes
 consul_ca_file: ca.cert
 consul_cert_file: consul.cert

--- a/roles/consul/defaults/main.yml
+++ b/roles/consul/defaults/main.yml
@@ -7,9 +7,10 @@ consul_dc_group: dc={{ consul_dc }}
 consul_servers_group: role=control
 consul_log_level: "warn"
 consul_is_server: "{{ consul_servers_group in group_names }}"
+consul_controller_override: "{{ consul_servers_group in groups }}"
 consul_advertise: "{{ private_ipv4 }}"
-consul_retry_join: "{% for host in groups[consul_servers_group] | intersect(groups[consul_dc_group]) %}\"{{ hostvars[host].private_ipv4 }}\"{% if not loop.last %}, {% endif %}{% endfor %}"
-consul_bootstrap_expect: "{{ groups[consul_servers_group] | intersect(groups[consul_dc_group]) | length }}"
+consul_retry_join: "{% if consul_controller_override %}{% for host in groups[consul_servers_group] | intersect(groups[consul_dc_group]) %}\"{{ hostvars[host].private_ipv4 }}\"{% if not loop.last %},{% endif %}{% endfor %}{% endif %}{% if not consul_controller_override  %}{% for controller in consul_servers_group_override %}\"{{ controller }}\"{% if not loop.last %},{% endif %} {% endfor%} {% endif %}"
+consul_bootstrap_expect: "{% if consul_controller_override %}{{ groups[consul_servers_group] | intersect(groups[consul_dc_group]) | length }}{% endif %}"
 consul_disable_remote_exec: yes
 consul_ca_file: ca.cert
 consul_cert_file: consul.cert

--- a/roles/consul/defaults/main.yml
+++ b/roles/consul/defaults/main.yml
@@ -9,8 +9,8 @@ consul_log_level: "warn"
 consul_is_server: "{{ consul_servers_group in group_names }}"
 consul_controller_override: "{{ consul_servers_group in groups }}"
 consul_advertise: "{{ private_ipv4 }}"
-consul_retry_join: "{% if consul_controller_override %}{% for host in groups[consul_servers_group] | intersect(groups[consul_dc_group]) %}\"{{ hostvars[host].private_ipv4 }}\"{% if not loop.last %},{% endif %}{% endfor %}{% endif %}{% if not consul_controller_override  %}{% for controller in consul_servers_group_override %}\"{{ controller }}\"{% if not loop.last %},{% endif %} {% endfor%} {% endif %}"
-consul_bootstrap_expect: "{% if consul_controller_override %}{{ groups[consul_servers_group] | intersect(groups[consul_dc_group]) | length }}{% endif %}"
+consul_retry_join: "{% if not consul_controller_override %}{% for host in groups[consul_servers_group] | intersect(groups[consul_dc_group]) %}\"{{ hostvars[host].private_ipv4 }}\"{% if not loop.last %},{% endif %}{% endfor %}{% endif %}{% if consul_controller_override  %}{% for controller in consul_servers_group_override %}\"{{ controller }}\"{% if not loop.last %},{% endif %} {% endfor%} {% endif %}"
+consul_bootstrap_expect: "{% if not consul_controller_override %}{{ groups[consul_servers_group] | intersect(groups[consul_dc_group]) | length }}{% endif %}"
 consul_disable_remote_exec: yes
 consul_ca_file: ca.cert
 consul_cert_file: consul.cert

--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -31,6 +31,7 @@
   sudo: yes
   command: consul join {{ item }}
   with_items: consul_retry_join
+  when: consul_servers_group_override is defined
   tags:
     - consul
 

--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -27,6 +27,11 @@
   tags:
     - consul
 
+- name: assert consul clustering
+  sudo: yes
+  command: consul join {{ item }}
+  with_items: consul_retry_join
+
 - name: register docker with consul
   sudo: yes
   copy:

--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -27,6 +27,14 @@
   tags:
     - consul
 
+- name: assert consul restarted
+  sudo: yes
+  command: systemctl restart consul.service
+  notify:
+    - restart consul
+  tags:
+    - consul
+
 - name: assert consul clustering
   sudo: yes
   command: consul join {{ item }}

--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -30,8 +30,6 @@
 - name: assert consul restarted
   sudo: yes
   command: systemctl restart consul.service
-  notify:
-    - restart consul
   tags:
     - consul
 

--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -31,6 +31,8 @@
   sudo: yes
   command: consul join {{ item }}
   with_items: consul_retry_join
+  tags:
+    - consul
 
 - name: register docker with consul
   sudo: yes

--- a/roles/consul/tasks/nginx_proxy.yml
+++ b/roles/consul/tasks/nginx_proxy.yml
@@ -1,4 +1,9 @@
 ---
+
+- name: assert nginx folder
+  sudo: yes
+  file: path=/etc/nginx state=directory
+
 - name: deploy nginx template
   sudo: yes
   copy:

--- a/roles/consul/tasks/nginx_proxy.yml
+++ b/roles/consul/tasks/nginx_proxy.yml
@@ -3,6 +3,8 @@
 - name: assert nginx folder
   sudo: yes
   file: path=/etc/nginx state=directory
+  tags:
+    - consul
 
 - name: deploy nginx template
   sudo: yes

--- a/roles/etcd/templates/etcd.conf.j2
+++ b/roles/etcd/templates/etcd.conf.j2
@@ -6,10 +6,12 @@
 {% endfor -%}
 {% endmacro -%}
 
-{% if groups[etcd_group_name] and groups[etcd_group_name] | length > 1 %}
+{% if etcd_group_name in groups %} {%if groups[etcd_group_name] and
+groups[etcd_group_name] | length > 1  %}
 ETCD_NAME={{ inventory_hostname }}
 ETCD_LISTEN_PEER_URLS={{ etcd_listen_peer_urls }}
-{% else %}
+{% endif %}{% endif %}
+{% if etcd_group_name not in groups %}
 ETCD_NAME=default
 {% endif %}
 ETCD_DATA_DIR={{ etcd_data_dir }}
@@ -21,7 +23,8 @@ ETCD_LISTEN_CLIENT_URLS={{ etcd_listen_client_urls }}
 #ETCD_MAX_WALS="5"
 #ETCD_CORS=""
 
-{% if groups[etcd_group_name] and groups[etcd_group_name] | length > 1 %}
+{% if etcd_group_name in groups %}{% if groups[etcd_group_name] and
+groups[etcd_group_name] | length > 1 %}
 #[cluster]
 ETCD_INITIAL_ADVERTISE_PEER_URLS={{ etcd_initial_advertise_peer_urls }}
 ETCD_INITIAL_CLUSTER={{ initial_cluster() }}
@@ -30,7 +33,7 @@ ETCD_INITIAL_CLUSTER_TOKEN={{ etcd_initial_cluster_token }}
 #ETCD_DISCOVERY_SRV=""
 #ETCD_DISCOVERY_FALLBACK="proxy"
 #ETCD_DISCOVERY_PROXY=""
-{% endif %}
+{% endif %}{% endif %}
 ETCD_ADVERTISE_CLIENT_URLS={{ etcd_advertise_client_urls }}
 
 #[proxy]

--- a/roles/etcd/templates/skydns.env.j2
+++ b/roles/etcd/templates/skydns.env.j2
@@ -1,3 +1,3 @@
-ETCD_MACHINES={% for node in groups[etcd_group_name] %}{{ etcd_url_scheme }}://{{ node }}:{{ etcd_client_port }}{% if not loop.last %},{% endif %}{% endfor %}
+ETCD_MACHINES={% if etcd_group_name in groups %}{% for node in groups[etcd_group_name] %}{{ etcd_url_scheme }}://{{ node }}:{{ etcd_client_port }}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}
 
 SKYDNS_DOMAIN={{ cluster_name }}

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -25,8 +25,8 @@ mesos_attributes:
 mesos_cluster: mantl
 
 mesos_zk_auth: "{% if zk_mesos_user_secret is defined %}{{ zk_mesos_user }}:{{ zk_mesos_user_secret }}@{% endif %}"
-mesos_zk_dns: "zookeeper.service.consul"
-mesos_zk_hosts: "{% for host in groups[zookeeper_server_group] %}{{ host }}:{{mesos_zk_port}}{% if not loop.last %},{% endif %}{% endfor %}"
+mesos_zk_dns: "zoiokeeper.service.consul"
+mesos_zk_hosts: "{% if zookeeper_hosts_override is not defined %}{% for host in groups[zookeeper_server_group] %}{{ host }}:{{mesos_zk_port}}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}{% if zookeeper_hosts_override is defined %}{% for host in zookeeper_hosts_override %}{{ host }}:{{mesos_zk_port}}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}"
 mesos_zk_port: 2181
 mesos_zk_chroot: mesos
 mesos_zk: "zk://{{ mesos_zk_auth }}{{ mesos_zk_hosts }}/{{ mesos_zk_chroot }}"

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -25,7 +25,7 @@ mesos_attributes:
 mesos_cluster: mantl
 
 mesos_zk_auth: "{% if zk_mesos_user_secret is defined %}{{ zk_mesos_user }}:{{ zk_mesos_user_secret }}@{% endif %}"
-mesos_zk_dns: "zoiokeeper.service.consul"
+mesos_zk_dns: "zookeeper.service.consul"
 mesos_zk_hosts: "{% if zookeeper_hosts_override is not defined %}{% for host in groups[zookeeper_server_group] %}{{ host }}:{{mesos_zk_port}}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}{% if zookeeper_hosts_override is defined %}{% for host in zookeeper_hosts_override %}{{ host }}:{{mesos_zk_port}}{% if not loop.last %},{% endif %}{% endfor %}{% endif %}"
 mesos_zk_port: 2181
 mesos_zk_chroot: mesos

--- a/roles/mesos/tasks/nginx-proxy.yml
+++ b/roles/mesos/tasks/nginx-proxy.yml
@@ -1,4 +1,11 @@
 ---
+
+- name: assert nginx templates folder
+  sudo: yes
+  file: path=/etc/nginx/templates state=directory
+  tags:
+    - mesos
+
 - name: copy nginx configuration
   sudo: yes
   copy:


### PR DESCRIPTION
This feature makes minor changes to the core Ansible automation and is only conditionally activated if certain overriding variables are present. If these variables are not present the system behaves as expected.

Currently if the Mantl automation is run with only one Worker specified, the automation breaks. These changes support deployment of a single Mantl Worker.

The following variables need to be set in global_var/all/some_yaml_file.yml or a similarly functional location.
```
**hosts_core_override:** [
{"private_ipv4":"PRIVATEIP1","hostname":"mantl-control-03"},
{"private_ipv4":"PRIVATEIP2","hostname":"mantl-control-02"},
{"private_ipv4":"PRIVATEIP3","hostname":"mantl-control-01"} ]
**zookeeper_hosts_override:** ["mantl-control-03", "mantl-control-02", "mantl-control-01"]
**consul_servers_group_override:** ["PRIVATEIP1", "PRIVATEIP2", "PRIVATEIP3" ]
```