### PR TITLE
terraform.py: sync from upstream

### DIFF
--- a/plugins/inventory/terraform.py
+++ b/plugins/inventory/terraform.py
@@ -639,6 +639,41 @@ def clc_server(resource, module_name):
     return name, attrs, groups
 
 
+@parses('ucs_service_profile')
+@calculate_mantl_vars
+def ucs_host(resource, module_name):
+    name = resource['primary']['id']
+    raw_attrs = resource['primary']['attributes']
+    groups = []
+
+    # general attrs
+    attrs = {
+        'metadata': parse_dict(raw_attrs, 'metadata'),
+        'provider': 'ucs',
+    }
+
+    # attrs specific to mantl
+    attrs.update({
+        'consul_dc': _clean_dc(attrs['metadata'].get('dc', module_name)),
+        'role': attrs['metadata'].get('role', 'none'),
+    })
+
+    try:
+        attrs.update({
+            'ansible_ssh_host': raw_attrs['vNIC.0.ip'],
+            'public_ipv4': raw_attrs['vNIC.0.ip'],
+            'private_ipv4': raw_attrs['vNIC.0.ip']
+        })
+    except (KeyError, ValueError):
+        attrs.update({'ansible_ssh_host': '', 'publicly_routable': False})
+
+    # add groups based on attrs
+    groups.append('role=' + attrs['role']) #.get('role', 'none'))
+
+    # groups.append('all:children')
+    groups.append('dc=' + attrs['consul_dc'])
+
+    return name, attrs, groups
 
 ## QUERY TYPES
 def query_host(hosts, target):


### PR DESCRIPTION
Adds the UCS provider from https://github.com/CiscoCloud/terraform.py/pull/43. Does not add UCS into Mantl yet, but will help when that's available.

- [X] Installs cleanly on a fresh build of most recent master branch
- [X] Upgrades cleanly from the most recent release
- [X] Updates documentation relevant to the changes

