### PR TITLE
mesos: configurable isolation setting for agents

### DIFF
--- a/roles/mesos/README.rst
+++ b/roles/mesos/README.rst
@@ -85,6 +85,17 @@ You can use these variables to customize your Mesos installation.
 
    default: ``mesos-slave``
 
+.. data:: mesos_isolation
+
+   The isolation level for tasks using the `Mesos containerizer
+   <http://mesos.apache.org/documentation/latest/mesos-containerizer/>`_. See
+   the `Mesos Configuration documentation
+   <http://mesos.apache.org/documentation/latest/configuration/>`_ for more
+   information. If you wish to disable enforcement of cpu and memory resource
+   limits for tasks, set this to ``posix/cpu,posix/mem``.
+
+   default: ``cgroups/cpu,cgroups/mem``
+
 .. data:: mesos_attributes
    Set attributes for mesos agents.
    Provide these as a list to set multiple attributes. Format:

--- a/roles/mesos/defaults/main.yml
+++ b/roles/mesos/defaults/main.yml
@@ -15,6 +15,7 @@ mesos_follower_port: 5051
 mesos_leader_cmd: mesos-master
 mesos_follower_cmd: mesos-slave
 mesos_executor_registration_timeout: 10mins
+mesos_isolation: cgroups/cpu,cgroups/mem
 
 mesos_resources:
   - "ports(*):[4000-5000, 7000-8000, 9000-10000, 25000-26000, 31000-32000]"

--- a/roles/mesos/templates/mesos-agent.sysconfig.j2
+++ b/roles/mesos/templates/mesos-agent.sysconfig.j2
@@ -16,11 +16,12 @@ MESOS_RESOURCES={{ mesos_resources | join (";") }}
 MESOS_CONTAINERIZERS=docker,mesos
 MESOS_EXECUTOR_REGISTRATION_TIMEOUT={{ mesos_executor_registration_timeout }}
 MESOS_WORK_DIR={{ mesos_work_dir }}
+MESOS_ISOLATION={{ mesos_isolation }}
 
 # authentication
 {% if not (do_mesos_follower_auth|bool) %}# {% endif %}MESOS_CREDENTIAL=file:///etc/sysconfig/mesos-agent-credential
 
-EXTRA_OPTS="{% if calico_etcdaddr is defined %}--modules=file:///etc/calico/modules.json --isolation=com_mesosphere_mesos_NetworkIsolator --hooks=com_mesosphere_mesos_NetworkHook {% endif %}"
+EXTRA_OPTS="{% if calico_etcdaddr is defined %}--modules=file:///etc/calico/modules.json --isolation={{ mesos_isolation }},com_mesosphere_mesos_NetworkIsolator --hooks=com_mesosphere_mesos_NetworkHook {% endif %}"
 
 # calico integration
 {% if calico_etcdaddr is defined %}


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

* By default, use cgroups/cpu,cgroups/mem which will enforce cpu and memory limits for tasks running under the mesos containerizer

---

This should be tested with and without calico.

Before this change, Mesos would not enforce cpu and memory limits for tasks running in the Mesos containerizer (non-docker tasks). This is now configurable but the default has changed and limits will now be enforced. Is this acceptable or should we change the default back to the prior setting?