### PR TITLE
k8s: lock down permissions on certs

### DIFF
--- a/roles/kubernetes/files/make-ca-cert.sh
+++ b/roles/kubernetes/files/make-ca-cert.sh
@@ -89,6 +89,6 @@ done
 # Make private keys only readable by root
 keys=("server.key" "kubelet.key" "kubecfg.key")
 for key in "${keys[@]}"; do
-  sudo chown root:root "${cert_dir}/${key}"
+  chown root:root "${cert_dir}/${key}"
   chmod 0660 "${cert_dir}/${key}"
 done

--- a/roles/kubernetes/files/make-ca-cert.sh
+++ b/roles/kubernetes/files/make-ca-cert.sh
@@ -91,4 +91,4 @@ keys=("server.key" "kubelet.key" "kubecfg.key")
 for key in "${keys[@]}"; do
   sudo chown root:root "${cert_dir}/${key}"
   chmod 0660 "${cert_dir}/${key}"
-done"
+done

--- a/roles/kubernetes/files/make-ca-cert.sh
+++ b/roles/kubernetes/files/make-ca-cert.sh
@@ -81,12 +81,14 @@ cp -p pki/issued/kubelet.crt "${cert_dir}/kubelet.crt"
 cp -p pki/private/kubelet.key "${cert_dir}/kubelet.key"
 
 # Make public certificates readable by everyone
-for cert in "${cert_dir}/*.crt"; do
+certs=("ca.crt" "server.crt" "kubelet.crt" "kubecfg.crt")
+for cert in "${certs[@]}"; do
   chmod 0664 "${cert_dir}/${cert}"
 done
 
 # Make private keys only readable by root
-for key in "${cert_dir}/*.key"; do
+keys=("server.key" "kubelet.key" "kubecfg.key")
+for key in "${keys[@]}"; do
   sudo chown root:root "${cert_dir}/${key}"
   chmod 0660 "${cert_dir}/${key}"
 done"

--- a/roles/kubernetes/files/make-ca-cert.sh
+++ b/roles/kubernetes/files/make-ca-cert.sh
@@ -80,8 +80,13 @@ cp -p pki/private/kubecfg.key "${cert_dir}/kubecfg.key"
 cp -p pki/issued/kubelet.crt "${cert_dir}/kubelet.crt"
 cp -p pki/private/kubelet.key "${cert_dir}/kubelet.key"
 
-CERTS=("ca.crt" "server.key" "server.crt" "kubelet.key" "kubelet.crt" "kubecfg.key" "kubecfg.crt")
-for cert in "${CERTS[@]}"; do
-#   chgrp "${cert_group}" "${cert_dir}/${cert}"
-  chmod 666 "${cert_dir}/${cert}"
+# Make public certificates readable by everyone
+for cert in "${cert_dir}/*.crt"; do
+  chmod 0664 "${cert_dir}/${cert}"
 done
+
+# Make private keys only readable by root
+for key in "${cert_dir}/*.key"; do
+  sudo chown root:root "${cert_dir}/${key}"
+  chmod 0660 "${cert_dir}/${key}"
+done"


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

