### PR TITLE
Add playbook for recreating the etcd cluster

### DIFF
--- a/playbooks/recreate-etcd-cluster.yml
+++ b/playbooks/recreate-etcd-cluster.yml
@@ -1,0 +1,25 @@
+---
+
+# This playbook forces etcd to recreate cluster memembership allowing new memembers
+# to join the cluster.
+#
+# WARNING: this will delete all information stored in etcd for the entire cluster.
+
+- include: "{{ playbook_dir }}/check-requirements.yml"
+
+- hosts: all
+  gather_facts: no
+  tasks:
+    - name: Stop etcd
+      sudo: yes
+      service:
+        name: etcd
+        state: stopped
+    - name: Delete etcd data directory
+      sudo: yes
+      shell: rm -rf {{ etcd_data_dir }}/*
+    - name: Start etcd
+      sudo: yes
+      service:
+        name: etcd
+        state: started


### PR DESCRIPTION
I had issues with etcd when adding a new worker node to my cluster. The new worker was not able to join the existing cluster. This playbook will nuke the etcd data directory and restart etcd forcing etcd into new cluster mode where it allows new cluster members to join. 

There should be a way to programmatically add the new worker node however I was not successful in getting that to work... this is brute force and works.

- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

