### PR TITLE
Update generate-certificate to 0.1.1

### DIFF
--- a/roles/certificates/defaults/main.yml
+++ b/roles/certificates/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+generate_certificate_package: generate-certificate-0.1.1-1
+
 # Options passed to generate-certificate
 country: ""      # Default: US
 state: ""        # Default: New York

--- a/roles/certificates/tasks/main.yml
+++ b/roles/certificates/tasks/main.yml
@@ -10,8 +10,6 @@
     # CA public key
     - src: ssl/cacert.pem
       dest: /etc/pki/CA/ca.cert
-    - src: ssl/cacert.pem # https://github.com/asteris-llc/mantl-packaging/issues/90
-      dest: /etc/pki/CA/cacert.pem
     - src: ssl/cacert.pem
       dest: /etc/pki/ca-trust/source/cacert.pem
     - src: ssl/cacert.pem
@@ -27,7 +25,7 @@
 - name: install generate-certificate
   sudo: yes
   yum:
-    name: generate-certificate-0.0.1
+    name: "{{ generate_certificate_package }}"
     state: present
 
 - name: create certificate destination directory
@@ -43,6 +41,7 @@
   sudo: yes
   command: >
     generate-certificate
+    --cacert /etc/pki/CA/ca.cert
     {% if country != "" %} --country "{{ country }}" {% endif %}
     {% if state != "" %} --state "{{ state }}" {% endif %}
     {% if locality != "" %} --locality "{{ locality }}" {% endif %}


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

 * uses random serial number
 * doesn't depend on any certain cacert location

fixes #1551