### PR TITLE
always run certificates role

### DIFF
--- a/roles/chronos/meta/main.yml
+++ b/roles/chronos/meta/main.yml
@@ -1,7 +1,5 @@
 ---
 allow_duplicates: yes
 dependencies:
-  - role: certificates
-    when: do_chronos_ssl
   - role: distributive
     current_role: chronos

--- a/roles/consul/meta/main.yml
+++ b/roles/consul/meta/main.yml
@@ -1,8 +1,6 @@
 ---
 allow_duplicates: yes
 dependencies:
-  - role: certificates
-    when: do_consul_ssl
   - role: handlers
   - role: distributive
     current_role: consul

--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -2,5 +2,3 @@
 dependencies:
   - role: lvm
   - role: handlers
-  - role: certificates
-    when: docker_tcp and docker_tcp_tls

--- a/roles/mantlui/meta/main.yml
+++ b/roles/mantlui/meta/main.yml
@@ -1,7 +1,5 @@
 ---
 allow_duplicates: yes
 dependencies:
-  - role: certificates
-    when: do_mantlui_ssl
   - role: distributive
     current_role: mantlui

--- a/roles/marathon/meta/main.yml
+++ b/roles/marathon/meta/main.yml
@@ -1,5 +1,3 @@
 ---
 dependencies:
-  - role: certificates
-    when: do_marathon_ssl
   - role: handlers

--- a/roles/mesos/meta/main.yml
+++ b/roles/mesos/meta/main.yml
@@ -1,5 +1,3 @@
 ---
 dependencies:
-  - role: certificates
-    when: do_mesos_ssl
   - role: handlers

--- a/sample.yml
+++ b/sample.yml
@@ -19,6 +19,7 @@
     consul_servers_group: role=control
   roles:
     - common
+    - certificates
     - lvm
     - docker
     - logrotate


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

As @ChrisAubuchon pointed out, as we move to dynamic configuration via Consul Template, people can enable security after the initial installation. Therefore, to avoid problems in that scenario, certificates should be generated on every installation, even those that don't need them atm. 

As a bonus, this will make our installation faster and the logs cleaner. 

Should fix #1628 since the certificates role will run before anything else that depends on it. 
