### PR TITLE
security-setup: Clean up root CA generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@ docs/_build
 .vagrant
 security.yml
 ssl/**/*.pem
-ssl/index.txt*
-ssl/serial*
 ssl/.rnd
 .syncdir/
 

--- a/security-setup
+++ b/security-setup
@@ -147,10 +147,6 @@ cert_opts.add_argument(
     '--cert-email',
     default='operations@example.com',
     help='contact email for organizational unit')
-cert_opts.add_argument(
-    '--no-verify-certificates',
-    action='store_true',
-    help='skip verifying certificates as part of setup process')
 
 # mantlui
 mantlui_opts = parser.add_argument_group(
@@ -440,18 +436,6 @@ class Component(object):
 
         return status, out, err
 
-    def openssl_subject(self, common, **overrides):
-        return '/C={country}/ST={state}/L={locality}/O={organization}' \
-               '/OU={unit}/CN={common}/emailAddress={email}'.format(
-            country=overrides.get('country', self.args.cert_country),
-            state=overrides.get('state', self.args.cert_state),
-            locality=overrides.get('locality', self.args.cert_locality),
-            organization=overrides.get('organization', self.args.cert_organization),
-            unit=overrides.get('unit', self.args.cert_unit),
-            common=common,
-            email=overrides.get('email', self.args.cert_email)
-        )
-
     def toggle_boolean(self, inFlag, inValue, inDefault):
         with self.modify_security() as config:
             if inFlag not in config:
@@ -465,31 +449,27 @@ class Certificates(Component):
     def check(self):
         return [self.ca]
 
+    def openssl_subject(self, common, **overrides):
+        return '/C={country}/ST={state}/L={locality}/O={organization}' \
+               '/OU={unit}/CN={common}/emailAddress={email}'.format(
+            country=overrides.get('country', self.args.cert_country),
+            state=overrides.get('state', self.args.cert_state),
+            locality=overrides.get('locality', self.args.cert_locality),
+            organization=overrides.get('organization', self.args.cert_organization),
+            unit=overrides.get('unit', self.args.cert_unit),
+            common=common,
+            email=overrides.get('email', self.args.cert_email)
+        )
+
     def ca(self):
         "certificate authority"
-        serial = posixpath.join(CERT_PATH, 'serial')
-        if posixpath.exists(serial):
-            print('serial already exists')
-        else:
-            with open(serial, 'w') as fh:
-                fh.write('100001')
-
-            print('created serial')
-
-        index = posixpath.join(CERT_PATH, 'index.txt')
-        if posixpath.exists(index):
-            print('index already exists')
-        else:
-            open(index, 'w').close()
-            print('created index')
-
         with self.chdir(CERT_PATH):
-            if posixpath.exists(ROOT_KEY) or posixpath.exists(ROOT_CERT):
+            if posixpath.exists(ROOT_CERT):
                 print('root CA already exists')
             else:
                 self.wrap_call(
                     'openssl req -new -x509 -extensions v3_ca -nodes -subj "{}" '
-                    '-keyout {} -out {} -days 365 -config ./openssl.cnf'.format(
+                    '-keyout {} -out {} -days 3650 -config ./openssl.cnf'.format(
                         self.openssl_subject(
                             "security-setup"), ROOT_KEY, ROOT_CERT))
 


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

Less code is good code :recycle: 

from the commit message:
 1. Remove unused argument `--no-verify-certificates`
 2. Make `openssl_subject` part of the `Certificates` subclass instead of `Component`, as it's unused anywhere else
 3. Don't generate serial or index.txt, we only needed those for generating certificates.
 4. The CA must be generated if there's only a key present - we distribute the cert!
 5. Make the root CA valid for 10 years instead of 1 year. The root CA should always be valid for as long as possible! We should generate an intermediate CA if we want it to be short-lived.

