### PR TITLE
Increase the time waiting for a consul leader to be elected

### DIFF
--- a/roles/consul/files/consul-rolling-restart.sh
+++ b/roles/consul/files/consul-rolling-restart.sh
@@ -25,8 +25,11 @@ sleep 10
 # Verify that there is a leader before releasing the lock and restarting
 /usr/local/bin/consul-wait-for-leader.sh
 
-# Release the lock
-consul-cli kv-unlock ${ccargs} locks/consul --session=${sessionid}
+# Release the lock, trying up to 5 times
+for i in 1 2 3 4 5; do
+    consul-cli kv-unlock ${ccargs} locks/consul --session=${sessionid} && break
+    sleep 5
+done
 
 # Restart the service
 systemctl restart consul

--- a/roles/consul/files/consul-rolling-restart.sh
+++ b/roles/consul/files/consul-rolling-restart.sh
@@ -20,7 +20,7 @@ sessionid=$(consul-cli kv-lock ${ccargs} locks/consul)
 # Lock acquired. Pause briefly to allow the previous holder to restart
 # If it takes longer than five seconds run `systemctl restart consul`
 # after releasing the lock then we might cause a quorum outage
-sleep 5
+sleep 10
 
 # Verify that there is a leader before releasing the lock and restarting
 /usr/local/bin/consul-wait-for-leader.sh


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

When the consul leader is restarted by the consul-rolling-restart.sh, the unlocking of the `locks/consul` node can fail with `500` because the Consul cluster isn't quite ready despite the `/v1/status/leader` consul endpoint reporting that there is a leader. Increase the time waiting for the cluster to settle.