### PR TITLE
TRAVIS Force install to be noop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ env:
   - PROVIDER=softlayer
   - PROVIDER=triton
 
+install: echo "Skipping install step, everything is included in the docker image"
+
 before_script:
   - export TERRAFORM_FILE=testing/terraform/${PROVIDER}.tf
   - export CI_HEAD_COMMIT=$(git rev-list -n 1 --no-merges --branches="$(git rev-parse --abbrev-ref HEAD)" master...HEAD)


### PR DESCRIPTION
Travis CI runs an install script for python, even if the install key is
not defined in `.travis.yml`. So, I need to override that invocation. In
this instance, I'm overriding it with a message about how we are
skipping it. I'll need to have travis run a CI test on this to make sure
that it is working the way I want it to.