### PR TITLE
etcd: upgrade to 2.2.5

### DIFF
--- a/roles/etcd/defaults/main.yml
+++ b/roles/etcd/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-etcd_version: 2.1.1
+etcd_version: 2.2.5
 etcd_client_port: 2379
 etcd_peer_port: 2380
 
@@ -25,4 +25,3 @@ etcd_advertise_client_urls: "{{ etcd_url_scheme }}://{{ inventory_hostname }}:{{
 etcd_listen_client_urls: "{{ etcd_url_scheme }}://0.0.0.0:{{ etcd_client_port }}"
 
 etcd_data_dir: /var/lib/etcd
-


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

This is the latest version in the Centos repos. 

Related: #1678 