### PR TITLE
clean up digitalocean terraform configs

### DIFF
--- a/terraform/digitalocean.sample.tf
+++ b/terraform/digitalocean.sample.tf
@@ -1,13 +1,18 @@
+# All of your resources will be prefixed by this name
+variable "name" { default = "mantl" }
+
 provider "digitalocean" {
   token = ""
 }
 
 module "do-keypair" {
+  name = "${var.name}"
   source = "./terraform/digitalocean/keypair"
   public_key_filename = "~/.ssh/id_rsa.pub"
 }
 
 module "do-hosts" {
+  name = "${var.name}"
   source = "./terraform/digitalocean/hosts"
   ssh_key = "${module.do-keypair.keypair_id}"
   region_name = "nyc3" # this must be a region with metadata support

--- a/terraform/digitalocean/hosts/main.tf
+++ b/terraform/digitalocean/hosts/main.tf
@@ -1,21 +1,22 @@
 # input variables
-variable control_count { default = 3 }
-variable control_size { default = "4gb" }
-variable datacenter { default = "mi" }
-variable edge_count { default = 2 }
-variable edge_size { default = "2gb" }
+variable datacenter { default = "mantl" }
 variable image_name { default = "centos-7-2-x64" }
 variable region_name { default = "nyc3" }
-variable short_name { default = "mi" }
+variable name { default = "mantl" }
 variable ssh_key { }
+# Hosts
+variable control_count { default = 3 }
+variable control_size { default = "4gb" }
 variable worker_count { default = 3 }
-variable kubeworker_count { default = 0 }
 variable worker_size { default = "4gb" }
+variable edge_count { default = 2 }
+variable edge_size { default = "2gb" }
+variable kubeworker_count { default = 0 }
 
 # create resources
 resource "digitalocean_droplet" "control" {
   count = "${var.control_count}"
-  name = "${var.short_name}-control-${format("%02d", count.index+1)}"
+  name = "${var.name}-control-${format("%02d", count.index+1)}"
   image = "${var.image_name}"
   region = "${var.region_name}"
   size = "${var.control_size}"
@@ -25,7 +26,7 @@ resource "digitalocean_droplet" "control" {
 
 resource "digitalocean_droplet" "worker" {
   count = "${var.worker_count}"
-  name = "${var.short_name}-worker-${format("%03d", count.index+1)}"
+  name = "${var.name}-worker-${format("%03d", count.index+1)}"
   image = "${var.image_name}"
   region = "${var.region_name}"
   size = "${var.worker_size}"
@@ -35,7 +36,7 @@ resource "digitalocean_droplet" "worker" {
 
 resource "digitalocean_droplet" "kubeworker" {
   count = "${var.kubeworker_count}"
-  name = "${var.short_name}-kubeworker-${format("%03d", count.index+1)}"
+  name = "${var.name}-kubeworker-${format("%03d", count.index+1)}"
   image = "${var.image_name}"
   region = "${var.region_name}"
   size = "${var.worker_size}"
@@ -45,7 +46,7 @@ resource "digitalocean_droplet" "kubeworker" {
 
 resource "digitalocean_droplet" "edge" {
   count = "${var.edge_count}"
-  name = "${var.short_name}-edge-${format("%02d", count.index+1)}"
+  name = "${var.name}-edge-${format("%02d", count.index+1)}"
   image = "${var.image_name}"
   region = "${var.region_name}"
   size = "${var.edge_size}"

--- a/terraform/digitalocean/keypair/main.tf
+++ b/terraform/digitalocean/keypair/main.tf
@@ -1,10 +1,10 @@
 # input variables
-variable short_name { default = "mi" }
+variable name { default = "mantl" }
 variable public_key_filename { default = "~/.ssh/id_rsa.pub" }
 
 # create resources
 resource "digitalocean_ssh_key" "default" {
-  name = "${var.short_name}-key"
+  name = "${var.name}-key"
   public_key = "${file(var.public_key_filename)}"
 }
 

--- a/testing/terraform/do.tf
+++ b/testing/terraform/do.tf
@@ -4,15 +4,16 @@ provider "digitalocean" {
 }
 
 module "do-mantl-keypair" {
+  name = "ci-${var.build_number}"
   source = "./terraform/digitalocean/keypair"
   public_key_filename = "~/.ssh/id_rsa.pub"
 }
 
 module "do-mantl-hosts" {
+  name = "ci-${var.build_number}"
   source = "./terraform/digitalocean/hosts"
   ssh_key = "${module.do-mantl-keypair.keypair_id}"
   region_name = "sfo1" # this must be a region with metadata support
-  short_name = "mantl-ci-${var.build_number}"
 
   control_count = 3
   worker_count = 2


### PR DESCRIPTION
 * rename `short_name` to `name`
 * pass `name` to `do-keypair` and `do-hosts` by default
 * reorder host-related variables

- [x] Installs cleanly on a fresh build of most recent master branch
- [x] Upgrades cleanly from the most recent release
- [x] Updates documentation relevant to the changes

