### PR TITLE
lvm: fix parsing values of absolute amounts for volumes

### DIFF
--- a/roles/lvm/files/mantl-storage-setup.py
+++ b/roles/lvm/files/mantl-storage-setup.py
@@ -122,7 +122,7 @@ def process_vg(sec, params):
         subprocess.check_call([VGCREATE_CMD] + vgoptions + ['-s', str(pesize), name] + list(dev_list))
 
 pct_re = re.compile(r'^(\d+)%(PVS|LV|FREE)$')
-size_re = re.compile(r'^(\d+)[bskmgtpe]$')
+size_re = re.compile(r'^(\d+)([bskmgtpe])b?$')
 def parse_size(size):
     if size:
         m = pct_re.match(size)


### PR DESCRIPTION
This fix also is a candidate to stable branch 1.2

- [x] Installs cleanly on a fresh build of most recent master branch
- [ ] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes

