### PR TITLE
kubernetes gce cloud integration

### DIFF
--- a/group_vars/all/kubernetes_vars.yml
+++ b/group_vars/all/kubernetes_vars.yml
@@ -28,7 +28,7 @@ kube_users:
 cluster_name: cluster.local
 
 # Enable to leverage some unique features of a specific cloud provider.
-enable_cloud_provider: "{% if provider in ['aws'] %}True{% else %}False{% endif %}"
+enable_cloud_provider: "{% if provider in ['aws', 'gce'] %}True{% else %}False{% endif %}"
 cloud_provider: "{{ provider }}"
 
 # Kubernetes internal network for services, unused block of space.

--- a/roles/kubernetes/README.rst
+++ b/roles/kubernetes/README.rst
@@ -45,16 +45,17 @@ cluster.
 Cloud Provider Integration
 --------------------------
 
-As of 1.3, when you install Mantl on an AWS cluster, Kubernetes cloud provider
-integration will be enabled by default. Kubernetes will be able to natively
-manage some AWS resources (such as ELBs or EBS persistent volumes). If you wish
-to disable cloud provider integration, set the variable
-``enable_cloud_provider`` to ``false`` when building your cluster.
+Cloud provider integration is enabled by default for AWS and GCE clusters
+starting in Mantl 1.3. This means that Kubernetes can manage cloud-specific
+resources such as disk volumes and load balancers. If you wish to disable cloud
+provider integration, set the variable ``enable_cloud_provider`` to ``false``
+when building your cluster.
 
 .. note:: If you are planning on destroying your cluster with terraform, you
           should first use ``kubectl`` or the Kubernetes API to delete your
-          Kubernetes-managed AWS resources. Otherwise, it can cause your
-          ``terraform destroy`` command to fail.
+          Kubernetes-managed resources. Otherwise, it is possible that they will
+          interfere with your ability to successfully ``terraform destroy`` your
+          cluster.
 
 DNS Outline
 -----------

--- a/sample.yml
+++ b/sample.yml
@@ -30,38 +30,15 @@
     - dnsmasq
 
 # ROLES - after provisioning the software that's common to all hosts, we do
-# specialized hosts. This configuration has two major groups: control nodes and
-# worker nodes. We provision the worker nodes first so that we don't create any
-# race conditions. This could happen in the Mesos components - if there are no
-# worker nodes when trying to schedule control software, the deployment process
-# would hang.
-#
-# The worker role itself has a minimal configuration, as it's designed mainly to
-# run software that the Mesos leader shedules. It also forwards traffic to
-# globally known ports configured through Marathon.
-- hosts: role=worker
-  # role=worker hosts are a subset of "all". Since we already gathered facts on
-  # all servers, we can skip it here to speed up the deployment.
-  gather_facts: no
-  vars:
-    mesos_mode: follower
-    zookeeper_server_group: role=control
-  roles:
-    - mesos
-    - calico
+# specialized hosts. There are 4 built-in roles: control, workers (mesos),
+# kubeworkers (kubernetes), and edge (for external traffic into the cluster).
 
-- hosts: role=kubeworker
-  gather_facts: yes
-  roles:
-    - calico
-    - kubernetes
-    - kubernetes-node
-
-# the control nodes are necessarily more complex than the worker nodes, and have
-# ZooKeeper, Mesos, and Marathon leaders. In addition, they control Vault to
-# manage secrets in the cluster. These servers do not run applications by
-# themselves, they only schedule work. That said, there should be at least 3 of
-# them (and always an odd number) so that ZooKeeper can get and keep a quorum.
+# The control nodes are necessarily more complex than the worker nodes, and have
+# ZooKeeper, Mesos, and Marathon leaders as well as Kubernetes master
+# components. In addition, they control Vault to manage secrets in the cluster.
+# These servers do not run applications by themselves, they only schedule work.
+# That said, there should be at least 3 of them (and always an odd number) so
+# that ZooKeeper can get and keep a quorum.
 - hosts: role=control
   gather_facts: yes
   vars:
@@ -78,6 +55,29 @@
     - mantlui
     - kubernetes
     - kubernetes-master
+
+# The worker role itself has a minimal configuration, as it's designed mainly to
+# run software that the Mesos leader shedules. It also forwards traffic to
+# globally known ports configured through Marathon.
+- hosts: role=worker
+  # role=worker hosts are a subset of "all". Since we already gathered facts on
+  # all servers, we can skip it here to speed up the deployment.
+  gather_facts: no
+  vars:
+    mesos_mode: follower
+    zookeeper_server_group: role=control
+  roles:
+    - mesos
+    - calico
+
+# The kubeworker role is similar to the worker role but are intended for
+# Kubernetes workloads.
+- hosts: role=kubeworker
+  gather_facts: yes
+  roles:
+    - calico
+    - kubernetes
+    - kubernetes-node
 
 # The edge role exists solely for routing traffic into the cluster. Firewall
 # settings should be such that web traffic (ports 80 and 443) is exposed to the

--- a/terraform/gce/instance/main.tf
+++ b/terraform/gce/instance/main.tf
@@ -12,6 +12,7 @@ variable "short_name" {}
 variable "ssh_key" {}
 variable "ssh_user" {}
 variable "zones" {}
+variable "service_account_scopes" { default = "compute-rw,monitoring,logging-write,storage-ro,https://www.googleapis.com/auth/ndev.clouddns.readwrite" }
 
 
 # Instances
@@ -57,6 +58,10 @@ resource "google_compute_instance" "instance" {
     role = "${var.role}"
     sshKeys = "${var.ssh_user}:${file(var.ssh_key)} ${var.ssh_user}"
     ssh_user = "${var.ssh_user}"
+  }
+
+  service_account {
+    scopes = ["${split(",", var.service_account_scopes)}"]
   }
 
   count = "${var.count}"


### PR DESCRIPTION
- [x] Installs cleanly on a fresh build of most recent master branch
- [ ] Upgrades cleanly from the most recent release (n/a) - this will require the building of new instances so upgrades are not really supported for this feature
- [x] Updates documentation relevant to the changes

--- 


This allows kubernetes to manage things like Load Balancers and persistent volumes.

* enables cloud provider integration by default on gce
* adds service account scopes to gce instances

_Note: if you do not clean up kubernetes-created resources (like load balancers) in advance, terraform may not be able to destroy your cluster._

You can test the cloud integration by creating a Service with `type: LoadBalancer`. You can use the Kubernetes guestbook as an example. If you uncomment https://github.com/kubernetes/kubernetes/blob/master/examples/guestbook/all-in-one/guestbook-all-in-one.yaml#L130 and then run `kubectl create -f examples/guestbook/all-in-one/guestbook-all-in-one.yaml`, you should end up with a Load Balancer exposing the guestbook app externally. You can get the load balancer info by running `kubectl describe service frontend` or using the GCE UI/cli.

_Note: make sure to copy the changes in `sample.tf` to your local `mantl.yml` before testing._
