### PR TITLE
use mantl 1.3 repo

### DIFF
--- a/roles/consul/defaults/main.yml
+++ b/roles/consul/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 consul_package: consul-0.6.4
 consul_ui_package: consul-ui-0.6.4
-consul_cli_package: consul-cli-0.1.1
+consul_cli_package: consul-cli-0.3.1
 consul_dc: dc1
 consul_dc_group: dc={{ consul_dc }}
 consul_servers_group: role=control

--- a/roles/repos/defaults/main.yml
+++ b/roles/repos/defaults/main.yml
@@ -1,1 +1,1 @@
-mantl_version: 1.2
+mantl_version: 1.3


### PR DESCRIPTION
- [ ] Installs cleanly on a fresh build of most recent master branch
- [ ] Upgrades cleanly from the most recent release
- [ ] Updates documentation relevant to the changes (n/a)

---

WIP: not ready to merge. currently we get the following error:

`No Package matching 'distributive-0.2.5-1' found available, installed or updated`

We either need to push the `distributive-0.2.5-1` package into the repo or switch mantl to use distributive `0.3.0-1` but not sure of the status.

ping @siddharthist @Zogg 
