### PR TITLE
[terraform 0.7] fix compatibility with new terraform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
 env:
   global:
   - TF_VAR_build_number=${TRAVIS_JOB_NUMBER/./-}
-  - TERRAFORM_VERSION=0.7.0-rc2
+  - TERRAFORM_VERSION=0.7.0
   matrix:
   # These providers have a full battery of Terraform+Ansible tests
   - PROVIDER=aws DOCKER_SECRETS='-e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID'

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV MANTL_CONFIG_DIR /local
 
 VOLUME /root/.ssh
 
-ENV TERRAFORM_VERSION 0.7.0-rc2
+ENV TERRAFORM_VERSION 0.7.0
 RUN mkdir -p /tmp/terraform/ && \
     cd /tmp/terraform/ && \
     curl -SLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \

--- a/terraform/aws/aws.tf
+++ b/terraform/aws/aws.tf
@@ -481,21 +481,21 @@ output "default_security_group" {
 }
 
 output "control_ids" {
-  value = "${join(\",\", aws_instance.mi-control-nodes.*.id)}"
+  value = "${join(",", aws_instance.mi-control-nodes.*.id)}"
 }
 
 output "control_ips" {
-  value = "${join(\",\", aws_instance.mi-control-nodes.*.public_ip)}"
+  value = "${join(",", aws_instance.mi-control-nodes.*.public_ip)}"
 }
 
 output "worker_ips" {
-  value = "${join(\",\", aws_instance.mi-worker-nodes.*.public_ip)}"
+  value = "${join(",", aws_instance.mi-worker-nodes.*.public_ip)}"
 }
 
 output "kubeworker_ips" {
-  value = "${join(\",\", aws_instance.mi-kubeworker-nodes.*.public_ip)}"
+  value = "${join(",", aws_instance.mi-kubeworker-nodes.*.public_ip)}"
 }
 
 output "edge_ips" {
-  value = "${join(\",\", aws_instance.mi-edge-nodes.*.public_ip)}"
+  value = "${join(",", aws_instance.mi-edge-nodes.*.public_ip)}"
 }

--- a/terraform/aws/instance/main.tf
+++ b/terraform/aws/instance/main.tf
@@ -67,13 +67,13 @@ resource "aws_volume_attachment" "instance-lvm-attachment" {
 
 
 output "hostname_list" {
-  value = "${join(\",\", aws_instance.instance.*.tags.Name)}"
+  value = "${join(",", aws_instance.instance.*.tags.Name)}"
 }
 
 output "ec2_ids" {
-  value = "${join(\",\", aws_instance.instance.*.id)}"
+  value = "${join(",", aws_instance.instance.*.id)}"
 }
 
 output "ec2_ips" {
-  value = "${join(\",\", aws_instance.instance.*.public_ip)}"
+  value = "${join(",", aws_instance.instance.*.public_ip)}"
 }

--- a/terraform/aws/route53/dns/main.tf
+++ b/terraform/aws/route53/dns/main.tf
@@ -70,13 +70,13 @@ resource "aws_route53_record" "dns-wildcard" {
 }
 
 output "edge_fqdn" {
-  value = "${join(\",\", aws_route53_record.dns-edge.*.fqdn)}"
+  value = "${join(",", aws_route53_record.dns-edge.*.fqdn)}"
 }
 
 output "control_fqdn" {
-  value = "${join(\",\", aws_route53_record.dns-control.*.fqdn)}"
+  value = "${join(",", aws_route53_record.dns-control.*.fqdn)}"
 }
 
 output "worker_fqdn" {
-  value = "${join(\",\", aws_route53_record.dns-worker.*.fqdn)}"
+  value = "${join(",", aws_route53_record.dns-worker.*.fqdn)}"
 }

--- a/terraform/clc/node/main.tf
+++ b/terraform/clc/node/main.tf
@@ -70,11 +70,11 @@ resource "clc_public_ip" "ip" {
 }
 
 output "server_id" {
-  value = "${join(\",\", clc_server.node.*.id)}"
+  value = "${join(",", clc_server.node.*.id)}"
 }
 output "private_ip" {
-  value = "${join(\",\", clc_server.node.*.private_ip_address)}"
+  value = "${join(",", clc_server.node.*.private_ip_address)}"
 }
 output "public_ip" {
-  value = "${join(\",\", clc_server.node.*.public_ip_address)}"
+  value = "${join(",", clc_server.node.*.public_ip_address)}"
 }

--- a/terraform/digitalocean/hosts/main.tf
+++ b/terraform/digitalocean/hosts/main.tf
@@ -55,17 +55,17 @@ resource "digitalocean_droplet" "edge" {
 }
 
 output "control_ips" {
-  value = "${join(\",\", digitalocean_droplet.control.*.ipv4_address)}"
+  value = "${join(",", digitalocean_droplet.control.*.ipv4_address)}"
 }
 
 output "worker_ips" {
-  value = "${join(\",\", digitalocean_droplet.worker.*.ipv4_address)}"
+  value = "${join(",", digitalocean_droplet.worker.*.ipv4_address)}"
 }
 
 output "kubeworker_ips" {
-  value = "${join(\",\", digitalocean_droplet.kubeworker.*.ipv4_address)}"
+  value = "${join(",", digitalocean_droplet.kubeworker.*.ipv4_address)}"
 }
 
 output "edge_ips" {
-  value = "${join(\",\", digitalocean_droplet.edge.*.ipv4_address)}"
+  value = "${join(",", digitalocean_droplet.edge.*.ipv4_address)}"
 }

--- a/terraform/gce/gce.tf
+++ b/terraform/gce/gce.tf
@@ -299,17 +299,17 @@ resource "google_compute_instance" "mi-edge-nodes" {
 }
 
 output "control_ips" {
-  value = "${join(\",\", google_compute_instance.mi-control-nodes.*.network_interface.0.access_config.0.nat_ip)}"
+  value = "${join(",", google_compute_instance.mi-control-nodes.*.network_interface.0.access_config.0.nat_ip)}"
 }
 
 output "worker_ips" {
-  value = "${join(\",\", google_compute_instance.mi-worker-nodes.*.network_interface.0.access_config.0.nat_ip)}"
+  value = "${join(",", google_compute_instance.mi-worker-nodes.*.network_interface.0.access_config.0.nat_ip)}"
 }
 
 output "kubeworker_ips" {
-  value = "${join(\",\", google_compute_instance.mi-kubeworker-nodes.*.network_interface.0.access_config.0.nat_ip)}"
+  value = "${join(",", google_compute_instance.mi-kubeworker-nodes.*.network_interface.0.access_config.0.nat_ip)}"
 }
 
 output "edge_ips" {
-  value = "${join(\",\", google_compute_instance.mi-edge-nodes.*.network_interface.0.access_config.0.nat_ip)}"
+  value = "${join(",", google_compute_instance.mi-edge-nodes.*.network_interface.0.access_config.0.nat_ip)}"
 }

--- a/terraform/gce/instance/main.tf
+++ b/terraform/gce/instance/main.tf
@@ -74,7 +74,7 @@ resource "google_compute_instance" "instance" {
 
 
 output "gce_ips" {
-  value = "${join(\",\", google_compute_instance.instance.*.network_interface.0.access_config.0.assigned_nat_ip)}"
+  value = "${join(",", google_compute_instance.instance.*.network_interface.0.access_config.0.assigned_nat_ip)}"
 }
 
 output "instances" {

--- a/terraform/openstack/hosts-floating/main.tf
+++ b/terraform/openstack/hosts-floating/main.tf
@@ -208,17 +208,17 @@ resource "openstack_networking_router_interface_v2" "ms-router-interface" {
 }
 
 output "control_ips" {
-  value = "${join(\",\", openstack_compute_instance_v2.control.*.access_ip_v4)}"
+  value = "${join(",", openstack_compute_instance_v2.control.*.access_ip_v4)}"
 }
 
 output "worker_ips" {
-  value = "${join(\",\", openstack_compute_instance_v2.worker.*.access_ip_v4)}"
+  value = "${join(",", openstack_compute_instance_v2.worker.*.access_ip_v4)}"
 }
 
 output "kubeworker_ips" {
-  value = "${join(\",\", openstack_compute_instance_v2.kubeworker.*.access_ip_v4)}"
+  value = "${join(",", openstack_compute_instance_v2.kubeworker.*.access_ip_v4)}"
 }
 
 output "edge_ips" {
-  value = "${join(\",\", openstack_compute_instance_v2.edge.*.access_ip_v4)}"
+  value = "${join(",", openstack_compute_instance_v2.edge.*.access_ip_v4)}"
 }

--- a/terraform/openstack/hosts/main.tf
+++ b/terraform/openstack/hosts/main.tf
@@ -145,17 +145,17 @@ resource "openstack_compute_instance_v2" "edge" {
 }
 
 output "control_ips" {
-  value = "${join(\",\", openstack_compute_instance_v2.control.*.access_ip_v4)}"
+  value = "${join(",", openstack_compute_instance_v2.control.*.access_ip_v4)}"
 }
 
 output "worker_ips" {
-  value = "${join(\",\", openstack_compute_instance_v2.worker.*.access_ip_v4)}"
+  value = "${join(",", openstack_compute_instance_v2.worker.*.access_ip_v4)}"
 }
 
 output "kubeworker_ips" {
-  value = "${join(\",\", openstack_compute_instance_v2.kubeworker.*.access_ip_v4)}"
+  value = "${join(",", openstack_compute_instance_v2.kubeworker.*.access_ip_v4)}"
 }
 
 output "edge_ips" {
-  value = "${join(\",\", openstack_compute_instance_v2.edge.*.access_ip_v4)}"
+  value = "${join(",", openstack_compute_instance_v2.edge.*.access_ip_v4)}"
 }

--- a/terraform/openstack/network/main.tf
+++ b/terraform/openstack/network/main.tf
@@ -15,7 +15,7 @@ resource "openstack_networking_subnet_v2" "subnet" {
   network_id = "${openstack_networking_network_v2.network.id}"
   cidr = "${var.subnet_cidr}"
   ip_version = "${var.ip_version}"
-  dns_nameservers = ["${compact(split(\",\", var.dns_nameservers))}"]
+  dns_nameservers = ["${compact(split(",", var.dns_nameservers))}"]
   enable_dhcp = true
 }
 

--- a/terraform/softlayer/hosts/main.tf
+++ b/terraform/softlayer/hosts/main.tf
@@ -58,13 +58,13 @@ resource "softlayer_virtual_guest" "edge" {
 }
 
 output "control_ips" {
-  value = "${join(\",\", softlayer_virtual_guest.control.*.ipv4_address)}"
+  value = "${join(",", softlayer_virtual_guest.control.*.ipv4_address)}"
 }
 
 output "worker_ips" {
-  value = "${join(\",\", softlayer_virtual_guest.worker.*.ipv4_address)}"
+  value = "${join(",", softlayer_virtual_guest.worker.*.ipv4_address)}"
 }
 
 output "edge_ips" {
-  value = "${join(\",\", softlayer_virtual_guest.edge.*.ipv4_address)}"
+  value = "${join(",", softlayer_virtual_guest.edge.*.ipv4_address)}"
 }

--- a/terraform/triton/instance/main.tf
+++ b/terraform/triton/instance/main.tf
@@ -27,5 +27,5 @@ resource "triton_machine" "instance" {
 }
 
 output "ips" {
-  value = "${join(\",\", triton_machine.instance.*.primaryip)}"
+  value = "${join(",", triton_machine.instance.*.primaryip)}"
 }

--- a/terraform/vsphere/main.tf
+++ b/terraform/vsphere/main.tf
@@ -214,17 +214,17 @@ resource "vsphere_virtual_machine" "mi-edge-nodes" {
 }
 
 output "control_ips" {
-  value = "${join(\",\", vsphere_virtual_machine.mi-control-nodes.*.network_interface.0.ipv4_address)}"
+  value = "${join(",", vsphere_virtual_machine.mi-control-nodes.*.network_interface.0.ipv4_address)}"
 }
 
 output "worker_ips" {
-  value = "${join(\",\", vsphere_virtual_machine.mi-worker-nodes.*.network_interface.0.ipv4_address)}"
+  value = "${join(",", vsphere_virtual_machine.mi-worker-nodes.*.network_interface.0.ipv4_address)}"
 }
 
 output "kubeworker_ips" {
-  value = "${join(\",\", vsphere_virtual_machine.mi-kubeworker-nodes.*.network_interface.ipv4_address)}"
+  value = "${join(",", vsphere_virtual_machine.mi-kubeworker-nodes.*.network_interface.ipv4_address)}"
 }
 
 output "edge_ips" {
-  value = "${join(\",\", vsphere_virtual_machine.mi-edge-nodes.*.network_interface.0.ipv4_address)}"
+  value = "${join(",", vsphere_virtual_machine.mi-edge-nodes.*.network_interface.0.ipv4_address)}"
 }


### PR DESCRIPTION
As far as I understand this shouldn't be a compatibility problem, in the terraform 0.6 line the escaped-quotes bug was preserved for compatibility, and that bug was removed in 0.7. However, the unescaped-quotes method has been the correct format for quite some time.