### PR TITLE
mantl-storage-setup.py fix for AttributeError

### DIFF
--- a/roles/lvm/files/mantl-storage-setup.py
+++ b/roles/lvm/files/mantl-storage-setup.py
@@ -2,6 +2,7 @@
 import subprocess
 from ConfigParser import ConfigParser, NoOptionError
 import os
+import time
 import sys
 import re
 from contextlib import closing
@@ -145,7 +146,7 @@ def wait_for_device(dev):
         if os.path.exists(dev):
             print "--> Device {} appears in {} seconds".format(dev, sec)
             break
-        os.sleep(1)
+        time.sleep(1)
 
 
 def process_volume(sec, params):


### PR DESCRIPTION
tiny fix for `mantl-storage-setup.py`

``` python
>>> import os                                                                                                                                          
>>> os.sleep
Traceback (most recent call last):                                                                                                                     
  File "<stdin>", line 1, in <module>                                                                                                                  
AttributeError: 'module' object has no attribute 'sleep'                                                                                               
>>> import time                                                                                                                                        
>>> time.sleep                                                                                                                                         
<built-in function sleep>                                                                                                                              
>>>                
```
